### PR TITLE
refactor: 메일 읽음여부 변수명 변경 및 총 수익률 반올림

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/dto/response/MailsResponseDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/dto/response/MailsResponseDto.java
@@ -18,7 +18,7 @@ public class MailsResponseDto {
     private String content;
 
     @Schema(description = "읽음 여부")
-    private boolean readStatus;
+    private boolean unread;
 
     @Schema(description = "수신 시간")
     private LocalDateTime receivedAt;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/entity/Mails.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/entity/Mails.java
@@ -26,7 +26,7 @@ public class Mails extends BaseEntity {
 
     private String content;
 
-    private boolean readStatus = false;
+    private boolean unread = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "members_id")
@@ -36,12 +36,12 @@ public class Mails extends BaseEntity {
     public Mails(
             String subject,
             String content,
-            boolean readStatus,
+            boolean unread,
             LocalDateTime createdAt,
             Members members) {
         this.subject = subject;
         this.content = content;
-        this.readStatus = readStatus;
+        this.unread = unread;
         this.setCreatedAt(createdAt);
         this.members = members;
     }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/mapper/MailsMapper.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/mapper/MailsMapper.java
@@ -23,7 +23,7 @@ public class MailsMapper {
                                 MailsResponseDto.builder()
                                         .subject(mail.getSubject())
                                         .content(mail.getContent())
-                                        .readStatus(mail.isReadStatus())
+                                        .unread(mail.isUnread())
                                         .receivedAt(mail.getCreatedAt())
                                         .build())
                 .toList();

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/repository/MailsRepository.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/repository/MailsRepository.java
@@ -10,5 +10,5 @@ public interface MailsRepository extends JpaRepository<Mails, Long> {
 
     List<Mails> findByMembersId(Long memberId);
 
-    List<Mails> findByMembersIdAndReadStatus(Long memberId, boolean readStatus);
+    List<Mails> findByMembersIdAndUnread(Long memberId, boolean unread);
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/service/MailsService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/service/MailsService.java
@@ -39,7 +39,7 @@ public class MailsService {
     }
 
     @Transactional(readOnly = true)
-    public List<MailsResponseDto> getMailsByReadStatus(Long memberId, boolean readStatus) {
+    public List<MailsResponseDto> getMailsByReadStatus(Long memberId, boolean unread) {
 
         Members findMember =
                 membersRepository
@@ -47,7 +47,7 @@ public class MailsService {
                         .orElseThrow(() -> new NotFoundMemberException(memberId));
 
         List<Mails> mailsList =
-                mailsRepository.findByMembersIdAndReadStatus(findMember.getId(), readStatus);
+                mailsRepository.findByMembersIdAndUnread(findMember.getId(), unread);
 
         return mailsMapper.toDto(mailsList);
     }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/service/MailsService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/mails/service/MailsService.java
@@ -39,7 +39,7 @@ public class MailsService {
     }
 
     @Transactional(readOnly = true)
-    public List<MailsResponseDto> getMailsByReadStatus(Long memberId, boolean unread) {
+    public List<MailsResponseDto> getMailsByUnreadStatus(Long memberId, boolean unread) {
 
         Members findMember =
                 membersRepository

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/controller/MembersController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/controller/MembersController.java
@@ -117,7 +117,7 @@ public class MembersController implements MembersControllerSpec {
             return ResponseEntity.ok(allMails);
         }
 
-        List<MailsResponseDto> mailsByStatus = mailsService.getMailsByReadStatus(currentId, unread);
+        List<MailsResponseDto> mailsByStatus = mailsService.getMailsByUnreadStatus(currentId, unread);
         return ResponseEntity.ok(mailsByStatus);
     }
 

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/controller/MembersController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/controller/MembersController.java
@@ -117,7 +117,8 @@ public class MembersController implements MembersControllerSpec {
             return ResponseEntity.ok(allMails);
         }
 
-        List<MailsResponseDto> mailsByStatus = mailsService.getMailsByUnreadStatus(currentId, unread);
+        List<MailsResponseDto> mailsByStatus =
+                mailsService.getMailsByUnreadStatus(currentId, unread);
         return ResponseEntity.ok(mailsByStatus);
     }
 

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
@@ -64,7 +64,9 @@ public class PortfoliosService {
         }
 
         double totalProfitRate =
-                totalInvestment == 0 ? 0.0 : (double) totalProfit / totalInvestment * 100;
+                totalInvestment == 0
+                        ? 0.00
+                        : Math.round((double) totalProfit / totalInvestment * 100 * 100) / 100.0;
 
         return PortfoliosSummary.builder()
                 .totalEvaluationAmount(totalEvaluationAmount)

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
@@ -124,8 +124,7 @@ public class MailsServiceTest {
         assertTrue(result.get(0).isUnread());
 
         verify(membersRepository, times(1)).findById(memberId);
-        verify(mailsRepository, times(1))
-                .findByMembersIdAndUnread(testMember.getId(), readStatus);
+        verify(mailsRepository, times(1)).findByMembersIdAndUnread(testMember.getId(), readStatus);
         verify(mailsMapper, times(1)).toDto(anyList());
     }
 

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
@@ -113,11 +113,11 @@ public class MailsServiceTest {
         boolean readStatus = true;
 
         when(membersRepository.findById(memberId)).thenReturn(Optional.of(testMember));
-        when(mailsRepository.findByMembersIdAndReadStatus(testMember.getId(), readStatus))
+        when(mailsRepository.findByMembersIdAndUnread(testMember.getId(), readStatus))
                 .thenReturn(List.of(testMail2));
         when(mailsMapper.toDto(List.of(testMail2))).thenReturn(List.of(testDto2));
 
-        List<MailsResponseDto> result = mailsService.getMailsByReadStatus(memberId, readStatus);
+        List<MailsResponseDto> result = mailsService.getMailsByUnreadStatus(memberId, readStatus);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -125,7 +125,7 @@ public class MailsServiceTest {
 
         verify(membersRepository, times(1)).findById(memberId);
         verify(mailsRepository, times(1))
-                .findByMembersIdAndReadStatus(testMember.getId(), readStatus);
+                .findByMembersIdAndUnread(testMember.getId(), readStatus);
         verify(mailsMapper, times(1)).toDto(anyList());
     }
 
@@ -136,7 +136,7 @@ public class MailsServiceTest {
 
         assertThrows(
                 NotFoundMemberException.class,
-                () -> mailsService.getMailsByReadStatus(memberId, true));
+                () -> mailsService.getMailsByUnreadStatus(memberId, true));
 
         verify(membersRepository, times(1)).findById(memberId);
         verifyNoMoreInteractions(mailsRepository);

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/mails/service/MailsServiceTest.java
@@ -61,7 +61,7 @@ public class MailsServiceTest {
                 MailsResponseDto.builder()
                         .subject("Test Subject")
                         .content("Test Content")
-                        .readStatus(false)
+                        .unread(false)
                         .receivedAt(LocalDateTime.now())
                         .build();
 
@@ -69,7 +69,7 @@ public class MailsServiceTest {
                 MailsResponseDto.builder()
                         .subject("Test Subject2")
                         .content("Test Content2")
-                        .readStatus(true)
+                        .unread(true)
                         .receivedAt(LocalDateTime.now())
                         .build();
     }
@@ -121,7 +121,7 @@ public class MailsServiceTest {
 
         assertNotNull(result);
         assertEquals(1, result.size());
-        assertTrue(result.get(0).isReadStatus());
+        assertTrue(result.get(0).isUnread());
 
         verify(membersRepository, times(1)).findById(memberId);
         verify(mailsRepository, times(1))


### PR DESCRIPTION
## 관련 이슈
close #47 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->
## 개요
총 수익률을 반환할 때 소수점 아래 둘째자리에서 반올림 처리를 한 다음 반환하고, 
메일 엔티티의 읽음 여부를 나타내는 변수명을 헷갈리지 않게 변경합니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

