### PR TITLE
refactor : TradesRepositoryTest 성공하도록 수정

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/controller/KakaoPayControllerSpec.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/controller/KakaoPayControllerSpec.java
@@ -21,7 +21,7 @@ public interface KakaoPayControllerSpec {
             summary = "결제 준비",
             description =
                     "카카오페이 결제를 준비하고 결제 URL을 반환합니다. 다른 API는 리다이렉션 API라 따로 사용하진 않고 해당 API를 통해 반환된"
-                        + " next_redirect_pc_url 주소로 결제를 진행합니다.")
+                            + " next_redirect_pc_url 주소로 결제를 진행합니다.")
     @ApiResponses(
             value = {
                 @ApiResponse(

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/trades/repository/TradesRepositoryTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/trades/repository/TradesRepositoryTest.java
@@ -23,11 +23,9 @@ import java.time.LocalDateTime;
 @DataJpaTest
 class TradesRepositoryTest {
 
-    @Autowired
-    private TradesRepository tradesRepository;
+    @Autowired private TradesRepository tradesRepository;
 
-    @Autowired
-    private EntityManager em;
+    @Autowired private EntityManager em;
 
     @Test
     @DisplayName("기간 내 거래만 조회되는지 확인")

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/trades/repository/TradesRepositoryTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/trades/repository/TradesRepositoryTest.java
@@ -1,72 +1,79 @@
-// package io.gaboja9.mockstock.domain.trades.repository;
-//
-// import static org.assertj.core.api.Assertions.assertThat;
-//
-// import io.gaboja9.mockstock.domain.members.entity.Members;
-// import io.gaboja9.mockstock.domain.trades.entity.TradeType;
-// import io.gaboja9.mockstock.domain.trades.entity.Trades;
-//
-// import jakarta.persistence.EntityManager;
-//
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//
-// import java.time.LocalDate;
-// import java.time.LocalDateTime;
-// import java.util.List;
-//
-// @DataJpaTest
-// class TradesRepositoryTest {
-//
-//    @Autowired private TradesRepository tradesRepository;
-//
-//    @Autowired private EntityManager em;
-//
-//    @Test
-//    @DisplayName("기간 내 거래만 조회되는지 확인")
-//    void findByStockCodeOrStockNameAndCreatedAtBetween() {
-//        // given
-//        Members member =
-//                new Members(
-//                        null,
-//                        "test@example.com",
-//                        "testUser",
-//                        "google",
-//                        "test.png",
-//                        5000,
-//                        0,
-//                        LocalDateTime.now());
-//        em.persist(member);
-//        em.flush();
-//
-//        Long memberId = member.getId();
-//
-//        // 거래 - 기간 외
-//        Trades trade1 = new Trades("005930", "삼성전자", TradeType.BUY, 10, 70000, member);
-//        trade1.setCreatedAt(LocalDateTime.of(2025, 6, 25, 10, 0));
-//        em.persist(trade1);
-//
-//        // 거래 - 기간 내
-//        Trades trade2 = new Trades("005930", "삼성전자", TradeType.SELL, 5, 80000, member);
-//        trade2.setCreatedAt(LocalDateTime.of(2025, 7, 3, 10, 0));
-//        em.persist(trade2);
-//
-//        em.flush();
-//        em.clear();
-//
-//        // when
-//        LocalDateTime start = LocalDate.of(2025, 7, 1).atStartOfDay();
-//        LocalDateTime end = LocalDate.of(2025, 7, 8).atTime(23, 59, 59);
-//
-//        List<Trades> result =
-//                tradesRepository.findByStockCodeOrStockNameAndCreatedAtBetween(
-//                        "005930", "삼성전자", start, end, memberId);
-//
-//        // then
-//        assertThat(result).hasSize(1);
-//        assertThat(result.get(0).getTradeType()).isEqualTo(TradeType.SELL);
-//        assertThat(result.get(0).getCreatedAt()).isEqualTo(trade2.getCreatedAt());
-//    }
-// }
+package io.gaboja9.mockstock.domain.trades.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gaboja9.mockstock.domain.members.entity.Members;
+import io.gaboja9.mockstock.domain.trades.entity.TradeType;
+import io.gaboja9.mockstock.domain.trades.entity.Trades;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@DataJpaTest
+class TradesRepositoryTest {
+
+    @Autowired
+    private TradesRepository tradesRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("기간 내 거래만 조회되는지 확인")
+    void findByStockCodeOrStockNameAndCreatedAtBetween() {
+        // given
+        Members member =
+                new Members(
+                        null,
+                        "test@example.com",
+                        "testUser",
+                        "google",
+                        "test.png",
+                        5000,
+                        0,
+                        LocalDateTime.now());
+        em.persist(member);
+        em.flush();
+
+        Long memberId = member.getId();
+
+        // 거래 - 기간 외
+        Trades trade1 = new Trades("005930", "삼성전자", TradeType.BUY, 10, 70000, member);
+        trade1.setCreatedAt(LocalDateTime.of(2025, 6, 25, 10, 0));
+        em.persist(trade1);
+
+        // 거래 - 기간 내
+        Trades trade2 = new Trades("005930", "삼성전자", TradeType.SELL, 5, 80000, member);
+        trade2.setCreatedAt(LocalDateTime.of(2025, 7, 3, 10, 0));
+        em.persist(trade2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        LocalDateTime start = LocalDate.of(2025, 7, 1).atStartOfDay();
+        LocalDateTime end = LocalDate.of(2025, 7, 8).atTime(23, 59, 59);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        Page<Trades> resultPage =
+                tradesRepository.findByStockCodeOrStockNameAndCreatedAtBetween(
+                        "005930", "삼성전자", start, end, memberId, pageable);
+
+        // then
+        assertThat(resultPage.getTotalElements()).isEqualTo(1);
+        Trades resultTrade = resultPage.getContent().get(0);
+        assertThat(resultTrade.getTradeType()).isEqualTo(TradeType.SELL);
+        assertThat(resultTrade.getCreatedAt()).isEqualTo(trade2.getCreatedAt());
+    }
+}

--- a/MockStock/src/test/resources/application.yml
+++ b/MockStock/src/test/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: MockStock
 
+  profiles:
+    active: test
+
   datasource:
     url: ${DB_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 관련 이슈
close #57 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

## 개요
`@EnableJpaAuditing`이 자동으로 `Trades` 엔티티의 `createdAt`을 실행 시각으로 주입하고, `updatable = false` 때문에 setCreatedAt이 동작하지 않았습니다. 테스트 프로파일을 test로 설정하였고, 프로파일이 test가 아닐때에만 EnableJpaAuditing이 적용됩니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

