### PR TITLE
Feat/65 shs

### DIFF
--- a/MockStock/build.gradle
+++ b/MockStock/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    implementation 'org.springframework.security:spring-security-messaging'
+
 
 }
 

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/JwtChannelInterceptor.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/JwtChannelInterceptor.java
@@ -1,0 +1,40 @@
+package io.gaboja9.mockstock.global.config;
+
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message,
+        StompHeaderAccessor.class);
+
+    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+      String sessionId = accessor.getSessionId();
+
+      // Spring Security의 AnonymousAuthenticationToken 사용
+      AnonymousAuthenticationToken anonymousAuth = new AnonymousAuthenticationToken(
+          "anonymousUser",
+          "user_" + sessionId,
+          Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+      );
+
+      accessor.setUser(anonymousAuth);
+      log.info("WebSocket 연결: 세션={}, 익명 사용자 설정됨", sessionId);
+    }
+
+    return message;
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/JwtChannelInterceptor.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/JwtChannelInterceptor.java
@@ -1,7 +1,7 @@
 package io.gaboja9.mockstock.global.config;
 
-import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -12,29 +12,32 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+
 @Component
 @Slf4j
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
-  @Override
-  public Message<?> preSend(Message<?> message, MessageChannel channel) {
-    StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message,
-        StompHeaderAccessor.class);
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-      String sessionId = accessor.getSessionId();
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String sessionId = accessor.getSessionId();
 
-      // Spring Security의 AnonymousAuthenticationToken 사용
-      AnonymousAuthenticationToken anonymousAuth = new AnonymousAuthenticationToken(
-          "anonymousUser",
-          "user_" + sessionId,
-          Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
-      );
+            // Spring Security의 AnonymousAuthenticationToken 사용
+            AnonymousAuthenticationToken anonymousAuth =
+                    new AnonymousAuthenticationToken(
+                            "anonymousUser",
+                            "user_" + sessionId,
+                            Collections.singletonList(
+                                    new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
 
-      accessor.setUser(anonymousAuth);
-      log.info("WebSocket 연결: 세션={}, 익명 사용자 설정됨", sessionId);
+            accessor.setUser(anonymousAuth);
+            log.info("WebSocket 연결: 세션={}, 익명 사용자 설정됨", sessionId);
+        }
+
+        return message;
     }
-
-    return message;
-  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
         return http.authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers(
-                                                "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**")
+                                                "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**" , "/ws-stock", "/ws-stock/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
@@ -29,7 +29,11 @@ public class SecurityConfig {
         return http.authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers(
-                                                "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**" , "/ws-stock", "/ws-stock/**")
+                                                "/swagger-ui/**",
+                                                "/v3/api-docs/**",
+                                                "/actuator/**",
+                                                "/ws-stock",
+                                                "/ws-stock/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/exception/ErrorCode.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/exception/ErrorCode.java
@@ -31,7 +31,11 @@ public enum ErrorCode {
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "JWT-002", "유효하지 않은 토큰입니다."),
     JWT_TOKEN_MALFORMED(HttpStatus.UNAUTHORIZED, "JWT-003", "잘못된 형식의 토큰입니다."),
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "JWT-004", "토큰 서명이 유효하지 않습니다."),
-    JWT_TOKEN_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "JWT-005", "지원되지 않는 토큰입니다.");
+    JWT_TOKEN_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "JWT-005", "지원되지 않는 토큰입니다."),
+
+    // 구독관련 에러
+    INVALID_STOCK(HttpStatus.NOT_FOUND , "STOCK-001" , " 없는 주식 코드 입니다."),
+    SOCKET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SOCKET-001", "소켓 에러입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/exception/ErrorCode.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     JWT_TOKEN_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "JWT-005", "지원되지 않는 토큰입니다."),
 
     // 구독관련 에러
-    INVALID_STOCK(HttpStatus.NOT_FOUND , "STOCK-001" , " 없는 주식 코드 입니다."),
+    INVALID_STOCK(HttpStatus.NOT_FOUND, "STOCK-001", " 없는 주식 코드 입니다."),
     SOCKET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SOCKET-001", "소켓 에러입니다.");
 
     private final HttpStatus status;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/CustomWebSocketHandlerDecorator.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/CustomWebSocketHandlerDecorator.java
@@ -1,0 +1,34 @@
+package io.gaboja9.mockstock.global.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+
+@Slf4j
+public class CustomWebSocketHandlerDecorator extends WebSocketHandlerDecorator {
+
+  private final WebSocketSessionManager sessionManager;
+
+  public CustomWebSocketHandlerDecorator(
+      WebSocketHandler delegate,
+      WebSocketSessionManager sessionManager
+  ) {
+    super(delegate);
+    this.sessionManager = sessionManager;
+  }
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    sessionManager.registerSession(session);
+    super.afterConnectionEstablished(session);
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+      throws Exception {
+    sessionManager.removeSession(session.getId());
+    super.afterConnectionClosed(session, closeStatus);
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/CustomWebSocketHandlerDecorator.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/CustomWebSocketHandlerDecorator.java
@@ -1,6 +1,7 @@
 package io.gaboja9.mockstock.global.websocket;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketSession;
@@ -9,26 +10,24 @@ import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
 @Slf4j
 public class CustomWebSocketHandlerDecorator extends WebSocketHandlerDecorator {
 
-  private final WebSocketSessionManager sessionManager;
+    private final WebSocketSessionManager sessionManager;
 
-  public CustomWebSocketHandlerDecorator(
-      WebSocketHandler delegate,
-      WebSocketSessionManager sessionManager
-  ) {
-    super(delegate);
-    this.sessionManager = sessionManager;
-  }
+    public CustomWebSocketHandlerDecorator(
+            WebSocketHandler delegate, WebSocketSessionManager sessionManager) {
+        super(delegate);
+        this.sessionManager = sessionManager;
+    }
 
-  @Override
-  public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-    sessionManager.registerSession(session);
-    super.afterConnectionEstablished(session);
-  }
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        sessionManager.registerSession(session);
+        super.afterConnectionEstablished(session);
+    }
 
-  @Override
-  public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
-      throws Exception {
-    sessionManager.removeSession(session.getId());
-    super.afterConnectionClosed(session, closeStatus);
-  }
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+            throws Exception {
+        sessionManager.removeSession(session.getId());
+        super.afterConnectionClosed(session, closeStatus);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
@@ -15,45 +15,44 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @EnableWebSocket
 public class HantuWebSocketConfig implements WebSocketConfigurer {
 
-  @Value("${hantu-openapi.websocket-uri:ws://ops.koreainvestment.com:31000}")
-  private String websocketUri;
+    @Value("${hantu-openapi.websocket-uri:ws://ops.koreainvestment.com:31000}")
+    private String websocketUri;
 
-  @Override
-  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-  }
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {}
 
-  @Bean
-  public WebSocketClient webSocketClient() {
-    StandardWebSocketClient client = new StandardWebSocketClient();
+    @Bean
+    public WebSocketClient webSocketClient() {
+        StandardWebSocketClient client = new StandardWebSocketClient();
 
-    // 메세지가 버퍼보다 커 웹소켓이 종료되는 문제가 존재하여 버퍼의 크기르 설정하였습니다.
-    client.getUserProperties()
-        .put("org.apache.tomcat.websocket.textBufferSize", 5 * 1024 * 1024);
-    client.getUserProperties()
-        .put("org.apache.tomcat.websocket.binaryBufferSize", 5 * 1024 * 1024);
-    // 타임아웃 설정 (60초)
-    client.getUserProperties().put("org.apache.tomcat.websocket.IO_TIMEOUT_MS", "60000");
-    return client;
-  }
+        // 메세지가 버퍼보다 커 웹소켓이 종료되는 문제가 존재하여 버퍼의 크기르 설정하였습니다.
+        client.getUserProperties()
+                .put("org.apache.tomcat.websocket.textBufferSize", 5 * 1024 * 1024);
+        client.getUserProperties()
+                .put("org.apache.tomcat.websocket.binaryBufferSize", 5 * 1024 * 1024);
+        // 타임아웃 설정 (60초)
+        client.getUserProperties().put("org.apache.tomcat.websocket.IO_TIMEOUT_MS", "60000");
+        return client;
+    }
 
-  @Bean
-  public HantuWebSocketConnectionManager HantuWebSocketConnectionManager(
-      WebSocketClient webSocketClient,
-      HantuWebSocketHandler handler,
-      HantuWebSocketSessionManager webSocketEventService) {
+    @Bean
+    public HantuWebSocketConnectionManager HantuWebSocketConnectionManager(
+            WebSocketClient webSocketClient,
+            HantuWebSocketHandler handler,
+            HantuWebSocketSessionManager webSocketEventService) {
 
-    HantuWebSocketConnectionManager connectionManager =
-        new HantuWebSocketConnectionManager(
-            webSocketClient, handler, websocketUri, webSocketEventService);
-    // 자동 시작을 비활성화하고, ApplicationReadyEvent를 통해 명시적으로 시작합니다.
-    connectionManager.setAutoStartup(false);
-    return connectionManager;
-  }
+        HantuWebSocketConnectionManager connectionManager =
+                new HantuWebSocketConnectionManager(
+                        webSocketClient, handler, websocketUri, webSocketEventService);
+        // 자동 시작을 비활성화하고, ApplicationReadyEvent를 통해 명시적으로 시작합니다.
+        connectionManager.setAutoStartup(false);
+        return connectionManager;
+    }
 
-  // 스프링 부트 애플리케이션이 완전히 준비된 후에 웹소켓 연결을 시작합니다. 이 방법을 사용하면 모든 Bean이 초기화된 후에 연결을 시도하므로 더 안정적입니다.
-  @Bean
-  public ApplicationListener<ApplicationReadyEvent> webSocketConnectionStarter(
-      HantuWebSocketConnectionManager connectionManager) {
-    return event -> connectionManager.startConnection();
-  }
+    // 스프링 부트 애플리케이션이 완전히 준비된 후에 웹소켓 연결을 시작합니다. 이 방법을 사용하면 모든 Bean이 초기화된 후에 연결을 시도하므로 더 안정적입니다.
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> webSocketConnectionStarter(
+            HantuWebSocketConnectionManager connectionManager) {
+        return event -> connectionManager.startConnection();
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
@@ -15,44 +15,45 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @EnableWebSocket
 public class HantuWebSocketConfig implements WebSocketConfigurer {
 
-    @Value("${hantu-openapi.websocket-uri:ws://ops.koreainvestment.com:31000}")
-    private String websocketUri;
+  @Value("${hantu-openapi.websocket-uri:ws://ops.koreainvestment.com:31000}")
+  private String websocketUri;
 
-    @Override
-    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {}
+  @Override
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+  }
 
-    @Bean
-    public WebSocketClient webSocketClient() {
-        StandardWebSocketClient client = new StandardWebSocketClient();
+  @Bean
+  public WebSocketClient webSocketClient() {
+    StandardWebSocketClient client = new StandardWebSocketClient();
 
-        // 메세지가 버퍼보다 커 웹소켓이 종료되는 문제가 존재하여 버퍼의 크기르 설정하였습니다.
-        client.getUserProperties()
-                .put("org.apache.tomcat.websocket.textBufferSize", 5 * 1024 * 1024);
-        client.getUserProperties()
-                .put("org.apache.tomcat.websocket.binaryBufferSize", 5 * 1024 * 1024);
-        // 타임아웃 설정 (60초)
-        client.getUserProperties().put("org.apache.tomcat.websocket.IO_TIMEOUT_MS", "60000");
-        return client;
-    }
+    // 메세지가 버퍼보다 커 웹소켓이 종료되는 문제가 존재하여 버퍼의 크기르 설정하였습니다.
+    client.getUserProperties()
+        .put("org.apache.tomcat.websocket.textBufferSize", 5 * 1024 * 1024);
+    client.getUserProperties()
+        .put("org.apache.tomcat.websocket.binaryBufferSize", 5 * 1024 * 1024);
+    // 타임아웃 설정 (60초)
+    client.getUserProperties().put("org.apache.tomcat.websocket.IO_TIMEOUT_MS", "60000");
+    return client;
+  }
 
-    @Bean
-    public HantuWebSocketConnectionManager HantuWebSocketConnectionManager(
-            WebSocketClient webSocketClient,
-            HantuWebSocketHandler handler,
-            HantuWebSocketSessionManager webSocketEventService) {
+  @Bean
+  public HantuWebSocketConnectionManager HantuWebSocketConnectionManager(
+      WebSocketClient webSocketClient,
+      HantuWebSocketHandler handler,
+      HantuWebSocketSessionManager webSocketEventService) {
 
-        HantuWebSocketConnectionManager connectionManager =
-                new HantuWebSocketConnectionManager(
-                        webSocketClient, handler, websocketUri, webSocketEventService);
-        // 자동 시작을 비활성화하고, ApplicationReadyEvent를 통해 명시적으로 시작합니다.
-        connectionManager.setAutoStartup(false);
-        return connectionManager;
-    }
+    HantuWebSocketConnectionManager connectionManager =
+        new HantuWebSocketConnectionManager(
+            webSocketClient, handler, websocketUri, webSocketEventService);
+    // 자동 시작을 비활성화하고, ApplicationReadyEvent를 통해 명시적으로 시작합니다.
+    connectionManager.setAutoStartup(false);
+    return connectionManager;
+  }
 
-    // 스프링 부트 애플리케이션이 완전히 준비된 후에 웹소켓 연결을 시작합니다. 이 방법을 사용하면 모든 Bean이 초기화된 후에 연결을 시도하므로 더 안정적입니다.
-    @Bean
-    public ApplicationListener<ApplicationReadyEvent> webSocketConnectionStarter(
-            HantuWebSocketConnectionManager connectionManager) {
-        return event -> connectionManager.startConnection();
-    }
+  // 스프링 부트 애플리케이션이 완전히 준비된 후에 웹소켓 연결을 시작합니다. 이 방법을 사용하면 모든 Bean이 초기화된 후에 연결을 시도하므로 더 안정적입니다.
+  @Bean
+  public ApplicationListener<ApplicationReadyEvent> webSocketConnectionStarter(
+      HantuWebSocketConnectionManager connectionManager) {
+    return event -> connectionManager.startConnection();
+  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConfig.java
@@ -13,7 +13,7 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @Configuration
 @EnableWebSocket
-public class WebSocketConfig implements WebSocketConfigurer {
+public class HantuWebSocketConfig implements WebSocketConfigurer {
 
     @Value("${hantu-openapi.websocket-uri:ws://ops.koreainvestment.com:31000}")
     private String websocketUri;
@@ -39,7 +39,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
     public HantuWebSocketConnectionManager HantuWebSocketConnectionManager(
             WebSocketClient webSocketClient,
             HantuWebSocketHandler handler,
-            WebSocketSessionManager webSocketEventService) {
+            HantuWebSocketSessionManager webSocketEventService) {
 
         HantuWebSocketConnectionManager connectionManager =
                 new HantuWebSocketConnectionManager(

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
@@ -1,87 +1,85 @@
 package io.gaboja9.mockstock.global.websocket;
 
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.web.socket.client.WebSocketClient;
-import org.springframework.web.socket.client.WebSocketConnectionManager;
-
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.WebSocketConnectionManager;
 
 @Slf4j
 public class HantuWebSocketConnectionManager extends WebSocketConnectionManager {
 
-    private final ScheduledExecutorService scheduler;
-    private ScheduledFuture<?> heartbeatTask;
-    private final HantuWebSocketSessionManager sessionManager;
-    private final HantuWebSocketHandler webSocketHandler;
+  private final ScheduledExecutorService scheduler;
+  private ScheduledFuture<?> heartbeatTask;
+  private final HantuWebSocketSessionManager sessionManager;
+  private final HantuWebSocketHandler webSocketHandler;
 
-    private volatile boolean running = false;
+  private volatile boolean running = false;
 
-    public HantuWebSocketConnectionManager(
-            WebSocketClient client,
-            HantuWebSocketHandler webSocketHandler,
-            String uriTemplate,
-            HantuWebSocketSessionManager sessionManager) {
-        super(client, webSocketHandler, uriTemplate);
-        this.scheduler = new ScheduledThreadPoolExecutor(1);
-        this.sessionManager = sessionManager;
-        this.webSocketHandler = webSocketHandler;
+  public HantuWebSocketConnectionManager(
+      WebSocketClient client,
+      HantuWebSocketHandler webSocketHandler,
+      String uriTemplate,
+      HantuWebSocketSessionManager sessionManager) {
+    super(client, webSocketHandler, uriTemplate);
+    this.scheduler = new ScheduledThreadPoolExecutor(1);
+    this.sessionManager = sessionManager;
+    this.webSocketHandler = webSocketHandler;
+  }
+
+  public void startConnection() {
+    log.info("Starting WebSocket connection manager");
+    this.running = true;
+    super.start();
+    startHeartbeat();
+  }
+
+  public void stopConnection() {
+    log.info("Stopping WebSocket connection manager");
+    this.running = false;
+    stopHeartbeat();
+    super.stop();
+  }
+
+  private void startHeartbeat() {
+    stopHeartbeat();
+    heartbeatTask =
+        scheduler.scheduleAtFixedRate(
+            () -> {
+              //  연결 상태 체크하여 재연결을 시도합니다.
+              if (this.running
+                  && (sessionManager.getSession() == null
+                  || !sessionManager.getSession().isOpen())) {
+                log.warn(
+                    "Heartbeat detected inactive session. Attempting to"
+                        + " reconnect...");
+                reconnect();
+              }
+            },
+            30,
+            30,
+            TimeUnit.SECONDS);
+    log.info("WebSocket heartbeat started");
+  }
+
+  private void stopHeartbeat() {
+    if (heartbeatTask != null && !heartbeatTask.isCancelled()) {
+      heartbeatTask.cancel(false);
+      log.info("WebSocket heartbeat stopped");
     }
+  }
 
-    public void startConnection() {
-        log.info("Starting WebSocket connection manager");
-        this.running = true;
-        super.start();
-        startHeartbeat();
+  private void reconnect() {
+    log.info("Attempting to reconnect WebSocket");
+    super.stop();
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
     }
-
-    public void stopConnection() {
-        log.info("Stopping WebSocket connection manager");
-        this.running = false;
-        stopHeartbeat();
-        super.stop();
-    }
-
-    private void startHeartbeat() {
-        stopHeartbeat();
-        heartbeatTask =
-                scheduler.scheduleAtFixedRate(
-                        () -> {
-                            //  연결 상태 체크하여 재연결을 시도합니다.
-                            if (this.running
-                                    && (sessionManager.getSession() == null
-                                            || !sessionManager.getSession().isOpen())) {
-                                log.warn(
-                                        "Heartbeat detected inactive session. Attempting to"
-                                                + " reconnect...");
-                                reconnect();
-                            }
-                        },
-                        30,
-                        30,
-                        TimeUnit.SECONDS);
-        log.info("WebSocket heartbeat started");
-    }
-
-    private void stopHeartbeat() {
-        if (heartbeatTask != null && !heartbeatTask.isCancelled()) {
-            heartbeatTask.cancel(false);
-            log.info("WebSocket heartbeat stopped");
-        }
-    }
-
-    private void reconnect() {
-        log.info("Attempting to reconnect WebSocket");
-        super.stop();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return;
-        }
-        super.start();
-    }
+    super.start();
+  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
@@ -15,7 +15,7 @@ public class HantuWebSocketConnectionManager extends WebSocketConnectionManager 
 
     private final ScheduledExecutorService scheduler;
     private ScheduledFuture<?> heartbeatTask;
-    private final WebSocketSessionManager sessionManager;
+    private final HantuWebSocketSessionManager sessionManager;
     private final HantuWebSocketHandler webSocketHandler;
 
     private volatile boolean running = false;
@@ -24,7 +24,7 @@ public class HantuWebSocketConnectionManager extends WebSocketConnectionManager 
             WebSocketClient client,
             HantuWebSocketHandler webSocketHandler,
             String uriTemplate,
-            WebSocketSessionManager sessionManager) {
+            HantuWebSocketSessionManager sessionManager) {
         super(client, webSocketHandler, uriTemplate);
         this.scheduler = new ScheduledThreadPoolExecutor(1);
         this.sessionManager = sessionManager;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketConnectionManager.java
@@ -1,85 +1,87 @@
 package io.gaboja9.mockstock.global.websocket;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.WebSocketConnectionManager;
+
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.socket.client.WebSocketClient;
-import org.springframework.web.socket.client.WebSocketConnectionManager;
 
 @Slf4j
 public class HantuWebSocketConnectionManager extends WebSocketConnectionManager {
 
-  private final ScheduledExecutorService scheduler;
-  private ScheduledFuture<?> heartbeatTask;
-  private final HantuWebSocketSessionManager sessionManager;
-  private final HantuWebSocketHandler webSocketHandler;
+    private final ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> heartbeatTask;
+    private final HantuWebSocketSessionManager sessionManager;
+    private final HantuWebSocketHandler webSocketHandler;
 
-  private volatile boolean running = false;
+    private volatile boolean running = false;
 
-  public HantuWebSocketConnectionManager(
-      WebSocketClient client,
-      HantuWebSocketHandler webSocketHandler,
-      String uriTemplate,
-      HantuWebSocketSessionManager sessionManager) {
-    super(client, webSocketHandler, uriTemplate);
-    this.scheduler = new ScheduledThreadPoolExecutor(1);
-    this.sessionManager = sessionManager;
-    this.webSocketHandler = webSocketHandler;
-  }
-
-  public void startConnection() {
-    log.info("Starting WebSocket connection manager");
-    this.running = true;
-    super.start();
-    startHeartbeat();
-  }
-
-  public void stopConnection() {
-    log.info("Stopping WebSocket connection manager");
-    this.running = false;
-    stopHeartbeat();
-    super.stop();
-  }
-
-  private void startHeartbeat() {
-    stopHeartbeat();
-    heartbeatTask =
-        scheduler.scheduleAtFixedRate(
-            () -> {
-              //  연결 상태 체크하여 재연결을 시도합니다.
-              if (this.running
-                  && (sessionManager.getSession() == null
-                  || !sessionManager.getSession().isOpen())) {
-                log.warn(
-                    "Heartbeat detected inactive session. Attempting to"
-                        + " reconnect...");
-                reconnect();
-              }
-            },
-            30,
-            30,
-            TimeUnit.SECONDS);
-    log.info("WebSocket heartbeat started");
-  }
-
-  private void stopHeartbeat() {
-    if (heartbeatTask != null && !heartbeatTask.isCancelled()) {
-      heartbeatTask.cancel(false);
-      log.info("WebSocket heartbeat stopped");
+    public HantuWebSocketConnectionManager(
+            WebSocketClient client,
+            HantuWebSocketHandler webSocketHandler,
+            String uriTemplate,
+            HantuWebSocketSessionManager sessionManager) {
+        super(client, webSocketHandler, uriTemplate);
+        this.scheduler = new ScheduledThreadPoolExecutor(1);
+        this.sessionManager = sessionManager;
+        this.webSocketHandler = webSocketHandler;
     }
-  }
 
-  private void reconnect() {
-    log.info("Attempting to reconnect WebSocket");
-    super.stop();
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return;
+    public void startConnection() {
+        log.info("Starting WebSocket connection manager");
+        this.running = true;
+        super.start();
+        startHeartbeat();
     }
-    super.start();
-  }
+
+    public void stopConnection() {
+        log.info("Stopping WebSocket connection manager");
+        this.running = false;
+        stopHeartbeat();
+        super.stop();
+    }
+
+    private void startHeartbeat() {
+        stopHeartbeat();
+        heartbeatTask =
+                scheduler.scheduleAtFixedRate(
+                        () -> {
+                            //  연결 상태 체크하여 재연결을 시도합니다.
+                            if (this.running
+                                    && (sessionManager.getSession() == null
+                                            || !sessionManager.getSession().isOpen())) {
+                                log.warn(
+                                        "Heartbeat detected inactive session. Attempting to"
+                                                + " reconnect...");
+                                reconnect();
+                            }
+                        },
+                        30,
+                        30,
+                        TimeUnit.SECONDS);
+        log.info("WebSocket heartbeat started");
+    }
+
+    private void stopHeartbeat() {
+        if (heartbeatTask != null && !heartbeatTask.isCancelled()) {
+            heartbeatTask.cancel(false);
+            log.info("WebSocket heartbeat stopped");
+        }
+    }
+
+    private void reconnect() {
+        log.info("Attempting to reconnect WebSocket");
+        super.stop();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        super.start();
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketHandler.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketHandler.java
@@ -233,14 +233,11 @@ public class HantuWebSocketHandler extends TextWebSocketHandler {
                 if (parts.length >= 4) {
                     String[] fields = parts[3].split("\\^");
                     StockPrice priceData = StockPriceMapper.parseStockPriceData(fields);
-                    //log.info(priceData.toString());
+                    // log.info(priceData.toString());
                     //  STOMP 브로드캐스트 추가
 
                     messagingTemplate.convertAndSend(
-                        "/topic/stock/" + priceData.getStockCode(),
-                        priceData
-                    );
-
+                            "/topic/stock/" + priceData.getStockCode(), priceData);
                 }
             } catch (Exception e) {
                 log.error("Error processing real-time data: {}", message, e);
@@ -276,9 +273,6 @@ public class HantuWebSocketHandler extends TextWebSocketHandler {
             log.warn("Could not parse JSON message: {}", message, e);
         }
     }
-
-
-
 
     //  /**
     //   * 재연결 후 기존 구독 복원

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketHandler.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketHandler.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.socket.CloseStatus;
@@ -46,7 +47,8 @@ public class HantuWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
-    private final WebSocketSessionManager eventService;
+    private final HantuWebSocketSessionManager eventService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     private WebSocketSession session;
     private String approvalKey;
@@ -231,7 +233,14 @@ public class HantuWebSocketHandler extends TextWebSocketHandler {
                 if (parts.length >= 4) {
                     String[] fields = parts[3].split("\\^");
                     StockPrice priceData = StockPriceMapper.parseStockPriceData(fields);
-                    log.info(priceData.toString());
+                    //log.info(priceData.toString());
+                    //  STOMP 브로드캐스트 추가
+
+                    messagingTemplate.convertAndSend(
+                        "/topic/stock/" + priceData.getStockCode(),
+                        priceData
+                    );
+
                 }
             } catch (Exception e) {
                 log.error("Error processing real-time data: {}", message, e);
@@ -267,6 +276,9 @@ public class HantuWebSocketHandler extends TextWebSocketHandler {
             log.warn("Could not parse JSON message: {}", message, e);
         }
     }
+
+
+
 
     //  /**
     //   * 재연결 후 기존 구독 복원

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketSessionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketSessionManager.java
@@ -1,0 +1,36 @@
+package io.gaboja9.mockstock.global.websocket;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+@Component
+@Slf4j
+public class HantuWebSocketSessionManager {
+
+  @Getter
+  private WebSocketSession session;
+  private boolean connectionActive = false;
+
+  // 세션설정
+  public void setSession(WebSocketSession session) {
+    this.session = session;
+    this.connectionActive = (session != null && session.isOpen());
+    log.info(
+        "WebSocket session set: {}, active: {}",
+        session != null ? session.getId() : "null",
+        connectionActive);
+  }
+
+  // 연결 상태 설정
+  public void setConnectionActive(boolean active) {
+    this.connectionActive = active;
+    log.info("WebSocket connection active state changed to: {}", active);
+  }
+
+  // 연결 상태 반환
+  public boolean isConnectionActive() {
+    return connectionActive;
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketSessionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/HantuWebSocketSessionManager.java
@@ -2,6 +2,7 @@ package io.gaboja9.mockstock.global.websocket;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -9,28 +10,27 @@ import org.springframework.web.socket.WebSocketSession;
 @Slf4j
 public class HantuWebSocketSessionManager {
 
-  @Getter
-  private WebSocketSession session;
-  private boolean connectionActive = false;
+    @Getter private WebSocketSession session;
+    private boolean connectionActive = false;
 
-  // 세션설정
-  public void setSession(WebSocketSession session) {
-    this.session = session;
-    this.connectionActive = (session != null && session.isOpen());
-    log.info(
-        "WebSocket session set: {}, active: {}",
-        session != null ? session.getId() : "null",
-        connectionActive);
-  }
+    // 세션설정
+    public void setSession(WebSocketSession session) {
+        this.session = session;
+        this.connectionActive = (session != null && session.isOpen());
+        log.info(
+                "WebSocket session set: {}, active: {}",
+                session != null ? session.getId() : "null",
+                connectionActive);
+    }
 
-  // 연결 상태 설정
-  public void setConnectionActive(boolean active) {
-    this.connectionActive = active;
-    log.info("WebSocket connection active state changed to: {}", active);
-  }
+    // 연결 상태 설정
+    public void setConnectionActive(boolean active) {
+        this.connectionActive = active;
+        log.info("WebSocket connection active state changed to: {}", active);
+    }
 
-  // 연결 상태 반환
-  public boolean isConnectionActive() {
-    return connectionActive;
-  }
+    // 연결 상태 반환
+    public boolean isConnectionActive() {
+        return connectionActive;
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StockSubscriptionInterceptor.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StockSubscriptionInterceptor.java
@@ -1,0 +1,56 @@
+package io.gaboja9.mockstock.global.websocket;
+
+import io.gaboja9.mockstock.global.exception.ErrorResponse;
+import io.gaboja9.mockstock.global.websocket.service.AvailableStockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class StockSubscriptionInterceptor implements ChannelInterceptor {
+
+  private final AvailableStockService availableStockService;
+  private final ObjectProvider<SimpMessagingTemplate> messagingTemplateProvider;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+      String destination = accessor.getDestination();
+      String sessionId = accessor.getSessionId();
+
+      if (destination != null && destination.startsWith("/topic/stock/")) {
+        String stockCode = destination.substring("/topic/stock/".length());
+
+        if (!availableStockService.isStockAvailable(stockCode)) {
+          log.warn("잘못된 종목코드 구독 시도: {} (session: {})", stockCode, sessionId);
+
+          String user = accessor.getUser() != null ? accessor.getUser().getName() : sessionId;
+
+          //  지연 주입으로 해결
+          messagingTemplateProvider.getObject().convertAndSendToUser(
+              user,
+              "/queue/errors",
+              ErrorResponse.of("INVALID_STOCK", "종목코드 '" + stockCode + "'는 존재하지 않습니다.", 400)
+          );
+
+          return null;
+        }
+
+        log.info("✅ 유효한 종목 구독: {} (session: {})", stockCode, sessionId);
+      }
+    }
+
+    return message;
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StockSubscriptionInterceptor.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StockSubscriptionInterceptor.java
@@ -2,8 +2,10 @@ package io.gaboja9.mockstock.global.websocket;
 
 import io.gaboja9.mockstock.global.exception.ErrorResponse;
 import io.gaboja9.mockstock.global.websocket.service.AvailableStockService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -18,39 +20,44 @@ import org.springframework.stereotype.Component;
 @Component
 public class StockSubscriptionInterceptor implements ChannelInterceptor {
 
-  private final AvailableStockService availableStockService;
-  private final ObjectProvider<SimpMessagingTemplate> messagingTemplateProvider;
+    private final AvailableStockService availableStockService;
+    private final ObjectProvider<SimpMessagingTemplate> messagingTemplateProvider;
 
-  @Override
-  public Message<?> preSend(Message<?> message, MessageChannel channel) {
-    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
-    if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-      String destination = accessor.getDestination();
-      String sessionId = accessor.getSessionId();
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String destination = accessor.getDestination();
+            String sessionId = accessor.getSessionId();
 
-      if (destination != null && destination.startsWith("/topic/stock/")) {
-        String stockCode = destination.substring("/topic/stock/".length());
+            if (destination != null && destination.startsWith("/topic/stock/")) {
+                String stockCode = destination.substring("/topic/stock/".length());
 
-        if (!availableStockService.isStockAvailable(stockCode)) {
-          log.warn("잘못된 종목코드 구독 시도: {} (session: {})", stockCode, sessionId);
+                if (!availableStockService.isStockAvailable(stockCode)) {
+                    log.warn("잘못된 종목코드 구독 시도: {} (session: {})", stockCode, sessionId);
 
-          String user = accessor.getUser() != null ? accessor.getUser().getName() : sessionId;
+                    String user =
+                            accessor.getUser() != null ? accessor.getUser().getName() : sessionId;
 
-          //  지연 주입으로 해결
-          messagingTemplateProvider.getObject().convertAndSendToUser(
-              user,
-              "/queue/errors",
-              ErrorResponse.of("INVALID_STOCK", "종목코드 '" + stockCode + "'는 존재하지 않습니다.", 400)
-          );
+                    //  지연 주입으로 해결
+                    messagingTemplateProvider
+                            .getObject()
+                            .convertAndSendToUser(
+                                    user,
+                                    "/queue/errors",
+                                    ErrorResponse.of(
+                                            "INVALID_STOCK",
+                                            "종목코드 '" + stockCode + "'는 존재하지 않습니다.",
+                                            400));
 
-          return null;
+                    return null;
+                }
+
+                log.info("✅ 유효한 종목 구독: {} (session: {})", stockCode, sessionId);
+            }
         }
 
-        log.info("✅ 유효한 종목 구독: {} (session: {})", stockCode, sessionId);
-      }
+        return message;
     }
-
-    return message;
-  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StompWebSocketConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StompWebSocketConfig.java
@@ -1,0 +1,55 @@
+package io.gaboja9.mockstock.global.websocket;
+
+import io.gaboja9.mockstock.global.config.JwtChannelInterceptor;
+import io.gaboja9.mockstock.global.websocket.exeception.WebSocketExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StockSubscriptionInterceptor stockSubscriptionInterceptor;
+  private final WebSocketExceptionHandler webSocketExceptionHandler;
+  private final JwtChannelInterceptor jwtChannelInterceptor;
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    // 클라이언트용 토픽 설정
+    config.enableSimpleBroker("/topic", "/queue");
+    // 클라이언트에서 서버로 메시지 전송시
+    config.setApplicationDestinationPrefixes("/app");
+    // 개인 메시지용 prefix
+    config.setUserDestinationPrefix("/user");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws-stock")
+        .setAllowedOriginPatterns("*")
+        .withSockJS();
+
+    registry.setErrorHandler(webSocketExceptionHandler);
+
+  }
+
+  // 추가: 메시지 인터셉터 등록
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stockSubscriptionInterceptor, jwtChannelInterceptor);
+  }
+
+  @Bean
+  public WebSocketHandlerDecoratorFactory webSocketHandlerDecoratorFactory(
+      WebSocketSessionManager sessionManager) {
+    return delegate -> new CustomWebSocketHandlerDecorator(delegate, sessionManager);
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StompWebSocketConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/StompWebSocketConfig.java
@@ -2,7 +2,9 @@ package io.gaboja9.mockstock.global.websocket;
 
 import io.gaboja9.mockstock.global.config.JwtChannelInterceptor;
 import io.gaboja9.mockstock.global.websocket.exeception.WebSocketExceptionHandler;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -17,39 +19,36 @@ import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 @RequiredArgsConstructor
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-  private final StockSubscriptionInterceptor stockSubscriptionInterceptor;
-  private final WebSocketExceptionHandler webSocketExceptionHandler;
-  private final JwtChannelInterceptor jwtChannelInterceptor;
+    private final StockSubscriptionInterceptor stockSubscriptionInterceptor;
+    private final WebSocketExceptionHandler webSocketExceptionHandler;
+    private final JwtChannelInterceptor jwtChannelInterceptor;
 
-  @Override
-  public void configureMessageBroker(MessageBrokerRegistry config) {
-    // 클라이언트용 토픽 설정
-    config.enableSimpleBroker("/topic", "/queue");
-    // 클라이언트에서 서버로 메시지 전송시
-    config.setApplicationDestinationPrefixes("/app");
-    // 개인 메시지용 prefix
-    config.setUserDestinationPrefix("/user");
-  }
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 클라이언트용 토픽 설정
+        config.enableSimpleBroker("/topic", "/queue");
+        // 클라이언트에서 서버로 메시지 전송시
+        config.setApplicationDestinationPrefixes("/app");
+        // 개인 메시지용 prefix
+        config.setUserDestinationPrefix("/user");
+    }
 
-  @Override
-  public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/ws-stock")
-        .setAllowedOriginPatterns("*")
-        .withSockJS();
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stock").setAllowedOriginPatterns("*").withSockJS();
 
-    registry.setErrorHandler(webSocketExceptionHandler);
+        registry.setErrorHandler(webSocketExceptionHandler);
+    }
 
-  }
+    // 추가: 메시지 인터셉터 등록
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stockSubscriptionInterceptor, jwtChannelInterceptor);
+    }
 
-  // 추가: 메시지 인터셉터 등록
-  @Override
-  public void configureClientInboundChannel(ChannelRegistration registration) {
-    registration.interceptors(stockSubscriptionInterceptor, jwtChannelInterceptor);
-  }
-
-  @Bean
-  public WebSocketHandlerDecoratorFactory webSocketHandlerDecoratorFactory(
-      WebSocketSessionManager sessionManager) {
-    return delegate -> new CustomWebSocketHandlerDecorator(delegate, sessionManager);
-  }
+    @Bean
+    public WebSocketHandlerDecoratorFactory webSocketHandlerDecoratorFactory(
+            WebSocketSessionManager sessionManager) {
+        return delegate -> new CustomWebSocketHandlerDecorator(delegate, sessionManager);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/WebSocketSessionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/WebSocketSessionManager.java
@@ -1,36 +1,44 @@
 package io.gaboja9.mockstock.global.websocket;
 
-import lombok.Getter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
-@Component
+@Service
 @Slf4j
 public class WebSocketSessionManager {
 
-    @Getter private WebSocketSession session;
-    private boolean connectionActive = false;
+  private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
 
-    // 세션설정
-    public void setSession(WebSocketSession session) {
-        this.session = session;
-        this.connectionActive = (session != null && session.isOpen());
-        log.info(
-                "WebSocket session set: {}, active: {}",
-                session != null ? session.getId() : "null",
-                connectionActive);
-    }
 
-    // 연결 상태 설정
-    public void setConnectionActive(boolean active) {
-        this.connectionActive = active;
-        log.info("WebSocket connection active state changed to: {}", active);
-    }
+  public void registerSession(WebSocketSession session) {
+    sessions.put(session.getId(), session);
+    log.info("Session registered: {}", session.getId());
+  }
 
-    // 연결 상태 반환
-    public boolean isConnectionActive() {
-        return connectionActive;
+  // 연결이 이미 닫힌 후 호출되는 cleanup 메서드
+  public void removeSession(String sessionId) {
+    WebSocketSession session = sessions.remove(sessionId);
+    if (session != null) {
+      log.info("Session removed from registry: {}", sessionId);
     }
+  }
+
+  // 능동적으로 연결을 끊을 때 사용하는 메서드
+  public void disconnectSession(String sessionId) {
+    WebSocketSession session = sessions.remove(sessionId);
+    if (session != null) {
+      log.info("Session removed: {}", sessionId);
+      try {
+        session.close();
+      } catch (IOException e) {
+        log.warn("Failed to close WebSocket session: {}", sessionId, e);
+      }
+    }
+  }
+
+
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/WebSocketSessionManager.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/WebSocketSessionManager.java
@@ -1,44 +1,43 @@
 package io.gaboja9.mockstock.global.websocket;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.socket.WebSocketSession;
 
 @Service
 @Slf4j
 public class WebSocketSessionManager {
 
-  private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+    private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
 
-
-  public void registerSession(WebSocketSession session) {
-    sessions.put(session.getId(), session);
-    log.info("Session registered: {}", session.getId());
-  }
-
-  // 연결이 이미 닫힌 후 호출되는 cleanup 메서드
-  public void removeSession(String sessionId) {
-    WebSocketSession session = sessions.remove(sessionId);
-    if (session != null) {
-      log.info("Session removed from registry: {}", sessionId);
+    public void registerSession(WebSocketSession session) {
+        sessions.put(session.getId(), session);
+        log.info("Session registered: {}", session.getId());
     }
-  }
 
-  // 능동적으로 연결을 끊을 때 사용하는 메서드
-  public void disconnectSession(String sessionId) {
-    WebSocketSession session = sessions.remove(sessionId);
-    if (session != null) {
-      log.info("Session removed: {}", sessionId);
-      try {
-        session.close();
-      } catch (IOException e) {
-        log.warn("Failed to close WebSocket session: {}", sessionId, e);
-      }
+    // 연결이 이미 닫힌 후 호출되는 cleanup 메서드
+    public void removeSession(String sessionId) {
+        WebSocketSession session = sessions.remove(sessionId);
+        if (session != null) {
+            log.info("Session removed from registry: {}", sessionId);
+        }
     }
-  }
 
-
+    // 능동적으로 연결을 끊을 때 사용하는 메서드
+    public void disconnectSession(String sessionId) {
+        WebSocketSession session = sessions.remove(sessionId);
+        if (session != null) {
+            log.info("Session removed: {}", sessionId);
+            try {
+                session.close();
+            } catch (IOException e) {
+                log.warn("Failed to close WebSocket session: {}", sessionId, e);
+            }
+        }
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/AvailableStockController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/AvailableStockController.java
@@ -1,0 +1,25 @@
+package io.gaboja9.mockstock.global.websocket.controller;
+
+import io.gaboja9.mockstock.global.websocket.service.AvailableStockService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AvailableStockController {
+
+  //TODO 주식 목록 가져오기로 변경예정
+  private final AvailableStockService availableStockService;
+
+  @GetMapping("/stocks/available")
+  public ResponseEntity<Map<String, Object>> getAvailableStocks() {
+    return ResponseEntity.ok(
+        Map.of("stocks", availableStockService.getAvailableStocksWithNames())
+    );
+  }
+
+
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/AvailableStockController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/AvailableStockController.java
@@ -1,25 +1,25 @@
 package io.gaboja9.mockstock.global.websocket.controller;
 
 import io.gaboja9.mockstock.global.websocket.service.AvailableStockService;
-import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class AvailableStockController {
 
-  //TODO 주식 목록 가져오기로 변경예정
-  private final AvailableStockService availableStockService;
+    // TODO 주식 목록 가져오기로 변경예정
+    private final AvailableStockService availableStockService;
 
-  @GetMapping("/stocks/available")
-  public ResponseEntity<Map<String, Object>> getAvailableStocks() {
-    return ResponseEntity.ok(
-        Map.of("stocks", availableStockService.getAvailableStocksWithNames())
-    );
-  }
-
-
+    @GetMapping("/stocks/available")
+    public ResponseEntity<Map<String, Object>> getAvailableStocks() {
+        return ResponseEntity.ok(
+                Map.of("stocks", availableStockService.getAvailableStocksWithNames()));
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/StockException.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/StockException.java
@@ -5,15 +5,15 @@ import io.gaboja9.mockstock.global.exception.ErrorCode;
 
 public class StockException extends BaseException {
 
-  public StockException() {
-    super(ErrorCode.INVALID_STOCK); // 기본 에러코드 설정
-  }
+    public StockException() {
+        super(ErrorCode.INVALID_STOCK); // 기본 에러코드 설정
+    }
 
-  public StockException(String message) {
-    super(ErrorCode.INVALID_STOCK, message); // 커스텀 메시지 허용
-  }
+    public StockException(String message) {
+        super(ErrorCode.INVALID_STOCK, message); // 커스텀 메시지 허용
+    }
 
-  public StockException(String message, Throwable cause) {
-    super(ErrorCode.INVALID_STOCK, message, cause); // 예외 체이닝
-  }
+    public StockException(String message, Throwable cause) {
+        super(ErrorCode.INVALID_STOCK, message, cause); // 예외 체이닝
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/StockException.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/StockException.java
@@ -1,0 +1,19 @@
+package io.gaboja9.mockstock.global.websocket.exeception;
+
+import io.gaboja9.mockstock.global.exception.BaseException;
+import io.gaboja9.mockstock.global.exception.ErrorCode;
+
+public class StockException extends BaseException {
+
+  public StockException() {
+    super(ErrorCode.INVALID_STOCK); // 기본 에러코드 설정
+  }
+
+  public StockException(String message) {
+    super(ErrorCode.INVALID_STOCK, message); // 커스텀 메시지 허용
+  }
+
+  public StockException(String message, Throwable cause) {
+    super(ErrorCode.INVALID_STOCK, message, cause); // 예외 체이닝
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/WebSocketExceptionHandler.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/WebSocketExceptionHandler.java
@@ -3,9 +3,10 @@ package io.gaboja9.mockstock.global.websocket.exeception;
 import io.gaboja9.mockstock.global.exception.ErrorCode;
 import io.gaboja9.mockstock.global.exception.ErrorResponse;
 import io.gaboja9.mockstock.global.websocket.WebSocketSessionManager;
-import java.net.SocketException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.annotation.SendToUser;
@@ -13,48 +14,44 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 
+import java.net.SocketException;
+
 @ControllerAdvice
 @RequiredArgsConstructor
 @Slf4j
 public class WebSocketExceptionHandler extends StompSubProtocolErrorHandler {
 
-  private final WebSocketSessionManager sessionManager;
+    private final WebSocketSessionManager sessionManager;
 
-  // @SendToUser 사용
-  @MessageExceptionHandler(SocketException.class)
-  @SendToUser("/queue/errors")
-  public ErrorResponse handleSocketException(Message<?> message) {
-    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-    String sessionId = accessor.getSessionId();
+    // @SendToUser 사용
+    @MessageExceptionHandler(SocketException.class)
+    @SendToUser("/queue/errors")
+    public ErrorResponse handleSocketException(Message<?> message) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        String sessionId = accessor.getSessionId();
 
-    log.error("Critical socket error from session: {}", sessionId);
+        log.error("Critical socket error from session: {}", sessionId);
 
-    // 시스템 에러는 연결 종료
-    sessionManager.disconnectSession(sessionId);
+        // 시스템 에러는 연결 종료
+        sessionManager.disconnectSession(sessionId);
 
-    return ErrorResponse.of(
-        ErrorCode.SOCKET_ERROR.getCode(),
-        "시스템 오류가 발생했습니다. 다시 연결해주세요.",
-        ErrorCode.SOCKET_ERROR.getStatus().value()
-    );
-  }
+        return ErrorResponse.of(
+                ErrorCode.SOCKET_ERROR.getCode(),
+                "시스템 오류가 발생했습니다. 다시 연결해주세요.",
+                ErrorCode.SOCKET_ERROR.getStatus().value());
+    }
 
-  // 서버 내부 오류
-  @MessageExceptionHandler(RuntimeException.class)
-  @SendToUser("/queue/errors")
-  public ErrorResponse handleRuntimeException(Message<?> message, RuntimeException ex) {
-    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-    String sessionId = accessor.getSessionId();
+    // 서버 내부 오류
+    @MessageExceptionHandler(RuntimeException.class)
+    @SendToUser("/queue/errors")
+    public ErrorResponse handleRuntimeException(Message<?> message, RuntimeException ex) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        String sessionId = accessor.getSessionId();
 
-    log.error("Unexpected runtime error from session: {}", sessionId, ex);
+        log.error("Unexpected runtime error from session: {}", sessionId, ex);
 
-    sessionManager.disconnectSession(sessionId);
+        sessionManager.disconnectSession(sessionId);
 
-    return ErrorResponse.of(
-        "INTERNAL_ERROR",
-        "서버 내부 오류가 발생했습니다.",
-        500
-    );
-  }
+        return ErrorResponse.of("INTERNAL_ERROR", "서버 내부 오류가 발생했습니다.", 500);
+    }
 }
-

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/WebSocketExceptionHandler.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/exeception/WebSocketExceptionHandler.java
@@ -1,0 +1,60 @@
+package io.gaboja9.mockstock.global.websocket.exeception;
+
+import io.gaboja9.mockstock.global.exception.ErrorCode;
+import io.gaboja9.mockstock.global.exception.ErrorResponse;
+import io.gaboja9.mockstock.global.websocket.WebSocketSessionManager;
+import java.net.SocketException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@ControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketExceptionHandler extends StompSubProtocolErrorHandler {
+
+  private final WebSocketSessionManager sessionManager;
+
+  // @SendToUser 사용
+  @MessageExceptionHandler(SocketException.class)
+  @SendToUser("/queue/errors")
+  public ErrorResponse handleSocketException(Message<?> message) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    String sessionId = accessor.getSessionId();
+
+    log.error("Critical socket error from session: {}", sessionId);
+
+    // 시스템 에러는 연결 종료
+    sessionManager.disconnectSession(sessionId);
+
+    return ErrorResponse.of(
+        ErrorCode.SOCKET_ERROR.getCode(),
+        "시스템 오류가 발생했습니다. 다시 연결해주세요.",
+        ErrorCode.SOCKET_ERROR.getStatus().value()
+    );
+  }
+
+  // 서버 내부 오류
+  @MessageExceptionHandler(RuntimeException.class)
+  @SendToUser("/queue/errors")
+  public ErrorResponse handleRuntimeException(Message<?> message, RuntimeException ex) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    String sessionId = accessor.getSessionId();
+
+    log.error("Unexpected runtime error from session: {}", sessionId, ex);
+
+    sessionManager.disconnectSession(sessionId);
+
+    return ErrorResponse.of(
+        "INTERNAL_ERROR",
+        "서버 내부 오류가 발생했습니다.",
+        500
+    );
+  }
+}
+

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/AvailableStockService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/AvailableStockService.java
@@ -1,0 +1,43 @@
+package io.gaboja9.mockstock.global.websocket.service;
+
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AvailableStockService {
+
+  //TODO 주식 목록 가져오기로 추후 변경
+  // 서버에서 구독하고 있는 주식 목록 (고정)
+  private static final Set<String> AVAILABLE_STOCKS = Set.of(
+      "005930", // 삼성전자
+      "035720", // 카카오
+      "035420" // 네이버
+
+      // 서버에서 실제로 구독하는 주식들만 추가
+  );
+
+  public Set<String> getAvailableStocks() {
+    return AVAILABLE_STOCKS;
+  }
+
+  public boolean isStockAvailable(String stockCode) {
+    return AVAILABLE_STOCKS.contains(stockCode);
+  }
+
+  // 주식명 매핑
+  private static final Map<String, String> STOCK_NAMES = Map.of(
+      "005930", "삼성전자",
+      "035720", "카카오",
+      "035420", "네이버"
+
+  );
+
+  public String getStockName(String stockCode) {
+    return STOCK_NAMES.getOrDefault(stockCode, stockCode);
+  }
+
+  public Map<String, String> getAvailableStocksWithNames() {
+    return STOCK_NAMES;
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/AvailableStockService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/AvailableStockService.java
@@ -1,43 +1,44 @@
 package io.gaboja9.mockstock.global.websocket.service;
 
+import org.springframework.stereotype.Service;
+
 import java.util.Map;
 import java.util.Set;
-import org.springframework.stereotype.Service;
 
 @Service
 public class AvailableStockService {
 
-  //TODO 주식 목록 가져오기로 추후 변경
-  // 서버에서 구독하고 있는 주식 목록 (고정)
-  private static final Set<String> AVAILABLE_STOCKS = Set.of(
-      "005930", // 삼성전자
-      "035720", // 카카오
-      "035420" // 네이버
+    // TODO 주식 목록 가져오기로 추후 변경
+    // 서버에서 구독하고 있는 주식 목록 (고정)
+    private static final Set<String> AVAILABLE_STOCKS =
+            Set.of(
+                    "005930", // 삼성전자
+                    "035720", // 카카오
+                    "035420" // 네이버
 
-      // 서버에서 실제로 구독하는 주식들만 추가
-  );
+                    // 서버에서 실제로 구독하는 주식들만 추가
+                    );
 
-  public Set<String> getAvailableStocks() {
-    return AVAILABLE_STOCKS;
-  }
+    public Set<String> getAvailableStocks() {
+        return AVAILABLE_STOCKS;
+    }
 
-  public boolean isStockAvailable(String stockCode) {
-    return AVAILABLE_STOCKS.contains(stockCode);
-  }
+    public boolean isStockAvailable(String stockCode) {
+        return AVAILABLE_STOCKS.contains(stockCode);
+    }
 
-  // 주식명 매핑
-  private static final Map<String, String> STOCK_NAMES = Map.of(
-      "005930", "삼성전자",
-      "035720", "카카오",
-      "035420", "네이버"
+    // 주식명 매핑
+    private static final Map<String, String> STOCK_NAMES =
+            Map.of(
+                    "005930", "삼성전자",
+                    "035720", "카카오",
+                    "035420", "네이버");
 
-  );
+    public String getStockName(String stockCode) {
+        return STOCK_NAMES.getOrDefault(stockCode, stockCode);
+    }
 
-  public String getStockName(String stockCode) {
-    return STOCK_NAMES.getOrDefault(stockCode, stockCode);
-  }
-
-  public Map<String, String> getAvailableStocksWithNames() {
-    return STOCK_NAMES;
-  }
+    public Map<String, String> getAvailableStocksWithNames() {
+        return STOCK_NAMES;
+    }
 }

--- a/MockStock/src/main/resources/application-local.yml
+++ b/MockStock/src/main/resources/application-local.yml
@@ -83,7 +83,7 @@ management:
         enabled: true
 
 hantu-openapi:
-  domain: https://openapivts.koreainvestment.com:29443
+  domain: https://openapi.koreainvestment.com:9443
   appkey: ${HANTU_APPKEY}
   appsecret: ${HANTU_APPSECRET}
 
@@ -141,4 +141,5 @@ logging:
     io.github.mockstock: DEBUG
     org.springframework.web: DEBUG
     org.springframework.web.client: DEBUG
+    org.springframework.web.SimpLogging: INFO
 


### PR DESCRIPTION
## 관련 이슈

### 1. STOMP 웹소켓 기능 구현
- `/ws-stock` 엔드포인트에 SockJS 지원 WebSocket 연결 가능
- `/topic/stock/{code}` 경로로 주식 코드별 실시간 구독 가능

### 2. 잘못된 구독 요청 에러 처리
- `StockSubscriptionInterceptor`를 통해 유효하지 않은 종목코드 구독 시 에러 메시지 전송
- 클라이언트가 `/user/queue/errors`를 구독하고 있으면 개별 에러 메시지를 수신함

### 3. WebSocket 연결/종료 세션 관리
- `WebSocketSessionManager`와 `CustomWebSocketHandlerDecorator`로 세션 저장 및 정리 구합니다.

### 4. 예외 발생 시 서버에서 클라이언트로 에러 메시지 전송
- `WebSocketExceptionHandler`에서 `@MessageExceptionHandler`를 통해 예외 발생 시 `/user/queue/errors`로 에러 전송
- `SocketException`, `RuntimeException` 등에 대한 대응 포함

## 개요


- `JwtChannelInterceptor`: 익명 사용자에게 세션 기반 사용자명 부여 (ex. user_{sessionId})
  JWT 를 사용하진 않은 비로그인 유저만 구현 되어있습니다. 로그인 유저를 관리하려면 추가 구현 필요합니다.
  
- `/stocks/available`: 유효한 주식 목록 REST API 제공
- `AvailableStockService`: 주식코드-이름 매핑, 서버에서 허용된 종목 목록 관리
  종목 가져오기 구현되면 그걸로 변경 예정입니다.
- `application-local.yml`의 하투 도메인 정보 수정 (실투자용)
 도메인이 실전투자 계좌로 바뀌면서 변경되어 반영하였습니다.
