### PR TITLE
refactor : 대기 상태의 주문 처리 로직에 가상 스레드 도입

### DIFF
--- a/MockStock/build.gradle
+++ b/MockStock/build.gradle
@@ -62,3 +62,15 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += "--enable-preview"
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs += "--enable-preview"
+}
+
+tasks.withType(JavaExec).configureEach {
+    jvmArgs += "--enable-preview"
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/repository/OrdersRepository.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/repository/OrdersRepository.java
@@ -20,7 +20,7 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
 
     @Query(
             "SELECT o FROM Orders o JOIN FETCH o.members WHERE o.status = :status AND o.orderType ="
-                + " :orderType ORDER BY o.createdAt ASC")
+                    + " :orderType ORDER BY o.createdAt ASC")
     List<Orders> findByStatusAndOrderTypeOrderByCreatedAtAsc(
             @Param("status") OrderStatus status, @Param("orderType") OrderType orderType);
 

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/service/LimitOrdersProcessor.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/service/LimitOrdersProcessor.java
@@ -1,8 +1,5 @@
 package io.gaboja9.mockstock.domain.orders.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import io.gaboja9.mockstock.domain.members.entity.Members;
 import io.gaboja9.mockstock.domain.orders.entity.OrderStatus;
 import io.gaboja9.mockstock.domain.orders.entity.OrderType;
@@ -15,17 +12,16 @@ import io.gaboja9.mockstock.domain.trades.entity.Trades;
 import io.gaboja9.mockstock.domain.trades.repository.TradesRepository;
 import io.gaboja9.mockstock.global.websocket.HantuWebSocketHandler;
 import io.gaboja9.mockstock.global.websocket.dto.StockPrice;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Component
 @RequiredArgsConstructor
@@ -38,54 +34,71 @@ public class LimitOrdersProcessor {
     private final HantuWebSocketHandler hantuWebSocketHandler;
     private final OrdersService ordersService;
 
-    // 동시성 제어를 위한 락 매니저
-    private final Cache<String, Object> memberLocks =
-            Caffeine.newBuilder()
-                    .maximumSize(10000)
-                    .expireAfterAccess(30, TimeUnit.MINUTES)
-                    .build();
+    // Virtual Thread 환경에서는 단순한 Semaphore 기반 동시성 제어가 더 효율적
+    private final ConcurrentHashMap<String, Semaphore> memberSemaphores = new ConcurrentHashMap<>();
 
     @Scheduled(fixedDelay = 1000)
     public void processLimitOrders() {
         if (!ordersService.openKoreanMarket()) return;
-        List<Orders> pendingOrders =
-                ordersRepository.findByStatusAndOrderTypeOrderByCreatedAtAsc(
-                        OrderStatus.PENDING, OrderType.LIMIT);
 
-        for (Orders order : pendingOrders) {
-            try {
-                processIndividualOrder(order);
-            } catch (Exception e) {
-                log.error("주문 처리 중 오류 발생 {}: {}", order.getId(), e.getMessage(), e);
-            }
+        List<Orders> pendingOrders = ordersRepository
+                .findByStatusAndOrderTypeOrderByCreatedAtAsc(OrderStatus.PENDING, OrderType.LIMIT);
+
+        if (pendingOrders.isEmpty()) {
+            return;
+        }
+
+        // Virtual Thread를 사용한 구조화된 동시성으로 모든 주문을 병렬 처리
+        try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+
+            // 각 주문을 Virtual Thread로 병렬 처리
+            List<StructuredTaskScope.Subtask<Object>> tasks = pendingOrders.stream()
+                    .map(order -> scope.fork(() -> {
+                        processIndividualOrder(order);
+                        return null;
+                    }))
+                    .toList();
+
+            scope.join();           // 모든 작업 완료 대기
+            scope.throwIfFailed();  // 실패한 작업이 있으면 예외 발생
+
+            log.debug("처리된 주문 수: {}", tasks.size());
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("주문 처리 중 인터럽트 발생", e);
+        } catch (Exception e) {
+            log.error("주문 처리 중 오류 발생", e);
         }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processIndividualOrder(Orders order) {
+        try {
+            Orders currentOrder = ordersRepository.findByIdWithMember(order.getId())
+                    .orElseThrow(() -> new NotFoundOrderException());
 
-        Orders currentOrder =
-                ordersRepository
-                        .findByIdWithMember(order.getId())
-                        .orElseThrow(() -> new NotFoundOrderException());
+            if (currentOrder.getStatus() != OrderStatus.PENDING) {
+                log.debug("이미 처리된 주문입니다. orderId={}, status={}",
+                        order.getId(), currentOrder.getStatus());
+                return;
+            }
 
-        if (currentOrder.getStatus() != OrderStatus.PENDING) {
-            log.debug(
-                    "이미 처리된 주문입니다. orderId={}, status={}", order.getId(), currentOrder.getStatus());
-            return;
-        }
+            StockPrice price = hantuWebSocketHandler.getLatestPrice(order.getStockCode());
+            if (price == null) {
+                log.warn("실시간 가격 정보 없음. orderId={}, stockCode={}",
+                        order.getId(), order.getStockCode());
+                return;
+            }
 
-        StockPrice price = hantuWebSocketHandler.getLatestPrice(order.getStockCode());
-        if (price == null) {
-            log.warn("실시간 가격 정보 없음. orderId={}, stockCode={}", order.getId(), order.getStockCode());
-            return;
-        }
+            int currentPrice = price.getCurrentPrice();
+            boolean shouldExecute = shouldExecuteOrder(currentOrder, currentPrice);
 
-        int currentPrice = price.getCurrentPrice();
-        boolean shouldExecute = shouldExecuteOrder(currentOrder, currentPrice);
-
-        if (shouldExecute) {
-            executeOrderWithLock(currentOrder, currentPrice);
+            if (shouldExecute) {
+                executeOrderWithSemaphore(currentOrder, currentPrice);
+            }
+        } catch (Exception e) {
+            log.error("주문 처리 중 오류 발생 {}: {}", order.getId(), e.getMessage(), e);
         }
     }
 
@@ -98,24 +111,36 @@ public class LimitOrdersProcessor {
         return false;
     }
 
-    private void executeOrderWithLock(Orders order, int executionPrice) {
+    private void executeOrderWithSemaphore(Orders order, int executionPrice) {
         String memberKey = "member_" + order.getMembers().getId();
+        Semaphore semaphore = memberSemaphores.computeIfAbsent(memberKey, k -> new Semaphore(1));
 
-        Object lock = memberLocks.get(memberKey, k -> new Object());
+        try {
+            // Virtual Thread는 블로킹에 강하므로 타임아웃을 길게 설정
+            if (semaphore.tryAcquire(30, TimeUnit.SECONDS)) {
+                try {
+                    // 가격 재확인
+                    StockPrice refreshed = hantuWebSocketHandler.getLatestPrice(order.getStockCode());
+                    if (refreshed == null) return;
 
-        synchronized (lock) {
-            try {
-                StockPrice refreshed = hantuWebSocketHandler.getLatestPrice(order.getStockCode());
-                if (refreshed == null) return;
-                int currentPrice = refreshed.getCurrentPrice();
-                if (!shouldExecuteOrder(order, currentPrice)) {
-                    log.debug("가격 재확인 후 조건 불만족으로 주문 보류.");
-                    return;
+                    int currentPrice = refreshed.getCurrentPrice();
+                    if (!shouldExecuteOrder(order, currentPrice)) {
+                        log.debug("가격 재확인 후 조건 불만족으로 주문 보류. orderId={}", order.getId());
+                        return;
+                    }
+
+                    executeOrder(order, executionPrice);
+                } finally {
+                    semaphore.release();
                 }
-                executeOrder(order, executionPrice);
-            } catch (Exception e) {
-                log.error("주문 실행 중 오류 발생: {}", e.getMessage(), e);
+            } else {
+                log.warn("세마포어 획득 타임아웃. orderId={}", order.getId());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("주문 실행 중 인터럽트 발생: orderId={}", order.getId(), e);
+        } catch (Exception e) {
+            log.error("주문 실행 중 오류 발생: orderId={}", order.getId(), e);
         }
     }
 
@@ -124,14 +149,14 @@ public class LimitOrdersProcessor {
         ordersRepository.save(order);
         Members member = order.getMembers();
 
-        Trades trade =
-                new Trades(
-                        order.getStockCode(),
-                        order.getStockName(),
-                        order.getTradeType(),
-                        order.getQuantity(),
-                        executionPrice,
-                        member);
+        Trades trade = new Trades(
+                order.getStockCode(),
+                order.getStockName(),
+                order.getTradeType(),
+                order.getQuantity(),
+                executionPrice,
+                member
+        );
         tradesRepository.save(trade);
 
         if (order.getTradeType() == TradeType.BUY) {
@@ -140,15 +165,23 @@ public class LimitOrdersProcessor {
             int refundAmount = frozenAmount - actualAmount;
 
             member.setCashBalance(member.getCashBalance() + refundAmount);
-            portfoliosService.updateForBuy(
-                    member.getId(),
-                    order.getStockCode(),
-                    order.getStockName(),
-                    order.getQuantity(),
-                    executionPrice);
+            portfoliosService.updateForBuy(member.getId(), order.getStockCode(),
+                    order.getStockName(), order.getQuantity(), executionPrice);
         } else if (order.getTradeType() == TradeType.SELL) {
             int actualAmount = executionPrice * order.getQuantity();
             member.setCashBalance(member.getCashBalance() + actualAmount);
         }
+
+        log.info("주문 체결 완료. orderId={}, type={}, price={}, quantity={}",
+                order.getId(), order.getTradeType(), executionPrice, order.getQuantity());
+    }
+
+    @Scheduled(fixedDelay = 300000) // 5분마다
+    public void cleanupSemaphores() {
+        // 사용하지 않는 세마포어 정리 로직
+        memberSemaphores.entrySet().removeIf(entry ->
+                entry.getValue().availablePermits() == 1 && !entry.getValue().hasQueuedThreads()
+        );
+        log.debug("세마포어 정리 완료. 현재 크기: {}", memberSemaphores.size());
     }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/service/OrdersService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/orders/service/OrdersService.java
@@ -1,8 +1,5 @@
 package io.gaboja9.mockstock.domain.orders.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import io.gaboja9.mockstock.domain.members.entity.Members;
 import io.gaboja9.mockstock.domain.members.exception.NotFoundMemberException;
 import io.gaboja9.mockstock.domain.members.repository.MembersRepository;
@@ -25,7 +22,6 @@ import io.gaboja9.mockstock.global.websocket.dto.StockPrice;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,8 +29,9 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 @Service
@@ -49,25 +46,24 @@ public class OrdersService {
     private final PortfoliosRepository portfoliosRepository;
     private final HantuWebSocketHandler hantuWebSocketHandler;
 
-    private final Cache<String, ReentrantLock> stockLocks =
-            Caffeine.newBuilder().expireAfterAccess(30, TimeUnit.MINUTES).build();
+    private final ConcurrentHashMap<String, Semaphore> stockSemaphores = new ConcurrentHashMap<>();
 
-    /** 종목 코드별로 락을 걸어서 자주 거래되는 종목의 경우 병목현상이 발생할 가능성이 있음.. */
-    private ReentrantLock getStockLock(String stockCode) {
-        return stockLocks.get(stockCode, key -> new ReentrantLock());
+    private Semaphore getStockSemaphore(String stockCode) {
+        return stockSemaphores.computeIfAbsent(stockCode, k -> new Semaphore(1));
     }
 
-    private <T> T executeWithStockLock(String stockCode, Supplier<T> task) {
-        ReentrantLock lock = getStockLock(stockCode);
+    private <T> T executeWithStockSemaphore(String stockCode, Supplier<T> task) {
+        Semaphore semaphore = getStockSemaphore(stockCode);
+
         try {
-            if (lock.tryLock(10, TimeUnit.SECONDS)) {
+            if (semaphore.tryAcquire(30, TimeUnit.SECONDS)) {
                 try {
                     if (!openKoreanMarket()) {
                         throw new NotOpenKoreanMarketException();
                     }
                     return task.get();
                 } finally {
-                    lock.unlock();
+                    semaphore.release();
                 }
             } else {
                 throw new OrderProcessingTimeoutException();
@@ -80,296 +76,237 @@ public class OrdersService {
 
     @Transactional
     public OrderResponseDto executeMarketBuyOrders(Long memberId, OrdersMarketTypeRequestDto dto) {
-        return executeWithStockLock(
-                dto.getStockCode(),
-                () -> {
-                    Members findMember =
-                            membersRepository
-                                    .findByIdWithLock(memberId)
-                                    .orElseThrow(() -> new NotFoundMemberException(memberId));
+        return executeWithStockSemaphore(dto.getStockCode(), () -> {
+            Members findMember =
+                    membersRepository
+                            .findByIdWithLock(memberId)
+                            .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-                    String stockCode = dto.getStockCode();
-                    String stockName = dto.getStockName();
-                    int quantity = dto.getQuantity();
+            String stockCode = dto.getStockCode();
+            String stockName = dto.getStockName();
+            int quantity = dto.getQuantity();
 
-                    Integer currentPrice = getCurrentPriceOrNull(stockCode);
-                    if (currentPrice == null) {
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("시장가 매수 실패: 현재 가격 정보를 불러올 수 없습니다.")
-                                .build();
-                    }
+            Integer currentPrice = getCurrentPriceOrNull(stockCode);
+            if (currentPrice == null) {
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("시장가 매수 실패: 현재 가격 정보를 불러올 수 없습니다.")
+                        .build();
+            }
 
-                    int totalPrice = currentPrice * quantity;
-                    int cashBalance = findMember.getCashBalance();
+            int totalPrice = currentPrice * quantity;
+            int cashBalance = findMember.getCashBalance();
 
-                    if (cashBalance < totalPrice) {
-                        throw new NotEnoughCashException(cashBalance);
-                    }
+            if (cashBalance < totalPrice) {
+                throw new NotEnoughCashException(cashBalance);
+            }
 
-                    Orders order =
-                            new Orders(
-                                    stockCode,
-                                    stockName,
-                                    OrderType.MARKET,
-                                    TradeType.BUY,
-                                    quantity,
-                                    currentPrice,
-                                    findMember);
-                    order.execute();
-                    ordersRepository.save(order);
+            Orders order = new Orders(stockCode, stockName, OrderType.MARKET, TradeType.BUY, quantity, currentPrice, findMember);
+            order.execute();
+            ordersRepository.save(order);
 
-                    Trades trade =
-                            new Trades(
-                                    stockCode,
-                                    stockName,
-                                    TradeType.BUY,
-                                    quantity,
-                                    currentPrice,
-                                    findMember);
-                    tradesRepository.save(trade);
+            Trades trade = new Trades(stockCode, stockName, TradeType.BUY, quantity, currentPrice, findMember);
+            tradesRepository.save(trade);
 
-                    findMember.setCashBalance(findMember.getCashBalance() - totalPrice);
+            findMember.setCashBalance(findMember.getCashBalance() - totalPrice);
 
-                    portfoliosService.updateForBuy(
-                            memberId, stockCode, stockName, quantity, currentPrice);
+            portfoliosService.updateForBuy(memberId, stockCode, stockName, quantity, currentPrice);
 
-                    return OrderResponseDto.builder()
-                            .executed(true)
-                            .message("시장가 매수 완료")
-                            .price(currentPrice)
-                            .build();
-                });
+            log.info("시장가 매수 완료. memberId={}, stockCode={}, quantity={}, price={}",
+                    memberId, stockCode, quantity, currentPrice);
+
+            return OrderResponseDto.builder()
+                    .executed(true)
+                    .message("시장가 매수 완료")
+                    .price(currentPrice)
+                    .build();
+        });
     }
 
     @Transactional
     public OrderResponseDto executeMarketSellOrders(Long memberId, OrdersMarketTypeRequestDto dto) {
-        return executeWithStockLock(
-                dto.getStockCode(),
-                () -> {
-                    Members findMember =
-                            membersRepository
-                                    .findByIdWithLock(memberId)
-                                    .orElseThrow(() -> new NotFoundMemberException(memberId));
+        return executeWithStockSemaphore(dto.getStockCode(), () -> {
+            Members findMember =
+                    membersRepository
+                            .findByIdWithLock(memberId)
+                            .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-                    String stockCode = dto.getStockCode();
-                    String stockName = dto.getStockName();
-                    int quantity = dto.getQuantity();
+            String stockCode = dto.getStockCode();
+            String stockName = dto.getStockName();
+            int quantity = dto.getQuantity();
 
-                    Portfolios portfolio =
-                            portfoliosRepository
-                                    .findByMembersIdAndStockCodeWithLock(memberId, stockCode)
-                                    .orElseThrow(() -> new NotFoundPortfolioException());
+            Portfolios portfolio = portfoliosRepository.findByMembersIdAndStockCodeWithLock(memberId, stockCode)
+                    .orElseThrow(() -> new NotFoundPortfolioException());
 
-                    if (portfolio.getQuantity() < quantity) {
-                        throw new InvalidSellQuantityException(quantity);
-                    }
+            if (portfolio.getQuantity() < quantity) {
+                throw new InvalidSellQuantityException(quantity);
+            }
 
-                    Integer currentPrice = getCurrentPriceOrNull(stockCode);
-                    if (currentPrice == null) {
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("시장가 매도 실패: 현재 가격 정보를 불러올 수 없습니다.")
-                                .build();
-                    }
+            Integer currentPrice = getCurrentPriceOrNull(stockCode);
+            if (currentPrice == null) {
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("시장가 매도 실패: 현재 가격 정보를 불러올 수 없습니다.")
+                        .build();
+            }
 
-                    int totalAmount = currentPrice * quantity;
+            int totalAmount = currentPrice * quantity;
 
-                    Orders order =
-                            new Orders(
-                                    stockCode,
-                                    stockName,
-                                    OrderType.MARKET,
-                                    TradeType.SELL,
-                                    quantity,
-                                    currentPrice,
-                                    findMember);
-                    order.execute();
-                    ordersRepository.save(order);
+            Orders order = new Orders(stockCode, stockName, OrderType.MARKET, TradeType.SELL, quantity, currentPrice, findMember);
+            order.execute();
+            ordersRepository.save(order);
 
-                    Trades trades =
-                            new Trades(
-                                    stockCode,
-                                    stockName,
-                                    TradeType.SELL,
-                                    quantity,
-                                    currentPrice,
-                                    findMember);
-                    tradesRepository.save(trades);
+            Trades trades = new Trades(stockCode, stockName, TradeType.SELL, quantity, currentPrice, findMember);
+            tradesRepository.save(trades);
 
-                    portfoliosService.updateForSell(memberId, stockCode, quantity);
+            portfoliosService.updateForSell(memberId, stockCode, quantity);
 
-                    findMember.setCashBalance(findMember.getCashBalance() + totalAmount);
+            findMember.setCashBalance(findMember.getCashBalance() + totalAmount);
 
-                    return OrderResponseDto.builder()
-                            .executed(true)
-                            .message("시장가 매도 완료")
-                            .price(currentPrice)
-                            .build();
-                });
+            log.info("시장가 매도 완료. memberId={}, stockCode={}, quantity={}, price={}",
+                    memberId, stockCode, quantity, currentPrice);
+
+            return OrderResponseDto.builder()
+                    .executed(true)
+                    .message("시장가 매도 완료")
+                    .price(currentPrice)
+                    .build();
+        });
     }
 
     @Transactional
     public OrderResponseDto executeLimitBuyOrders(Long memberId, OrdersLimitTypeRequestDto dto) {
-        return executeWithStockLock(
-                dto.getStockCode(),
-                () -> {
-                    Members findMember =
-                            membersRepository
-                                    .findByIdWithLock(memberId)
-                                    .orElseThrow(() -> new NotFoundMemberException(memberId));
+        return executeWithStockSemaphore(dto.getStockCode(), () -> {
+            Members findMember =
+                    membersRepository
+                            .findByIdWithLock(memberId)
+                            .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-                    String stockCode = dto.getStockCode();
-                    String stockName = dto.getStockName();
-                    int limitPrice = dto.getPrice();
-                    int quantity = dto.getQuantity();
-                    int cashBalance = findMember.getCashBalance();
+            String stockCode = dto.getStockCode();
+            String stockName = dto.getStockName();
+            int limitPrice = dto.getPrice();
+            int quantity = dto.getQuantity();
+            int cashBalance = findMember.getCashBalance();
 
-                    int totalAmount = limitPrice * quantity;
+            int totalAmount = limitPrice * quantity;
 
-                    if (cashBalance < totalAmount) {
-                        throw new NotEnoughCashException(cashBalance);
-                    }
+            if (cashBalance < totalAmount) {
+                throw new NotEnoughCashException(cashBalance);
+            }
 
-                    Orders order =
-                            new Orders(
-                                    stockCode,
-                                    stockName,
-                                    OrderType.LIMIT,
-                                    TradeType.BUY,
-                                    quantity,
-                                    limitPrice,
-                                    findMember);
+            Orders order = new Orders(stockCode, stockName, OrderType.LIMIT, TradeType.BUY, quantity, limitPrice, findMember);
 
-                    Integer currentPrice = getCurrentPriceOrNull(stockCode);
-                    if (currentPrice == null) {
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("지정가 매수 실패: 현재 가격 정보를 불러올 수 없습니다.")
-                                .build();
-                    }
+            Integer currentPrice = getCurrentPriceOrNull(stockCode);
+            if (currentPrice == null) {
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("지정가 매수 실패: 현재 가격 정보를 불러올 수 없습니다.")
+                        .build();
+            }
 
-                    if (currentPrice <= limitPrice) {
-                        // 즉시 체결
-                        order.execute();
-                        ordersRepository.save(order);
+            if (currentPrice <= limitPrice) {
+                // 즉시 체결
+                order.execute();
+                ordersRepository.save(order);
 
-                        // 거래 내역 저장
-                        Trades trade =
-                                new Trades(
-                                        stockCode,
-                                        stockName,
-                                        TradeType.BUY,
-                                        quantity,
-                                        currentPrice,
-                                        findMember);
-                        tradesRepository.save(trade);
+                Trades trade = new Trades(stockCode, stockName, TradeType.BUY, quantity, currentPrice, findMember);
+                tradesRepository.save(trade);
 
-                        // 잔고 차감 (실제 체결가 기준)
-                        int actualAmount = currentPrice * quantity;
-                        findMember.setCashBalance(findMember.getCashBalance() - actualAmount);
+                int actualAmount = currentPrice * quantity;
+                findMember.setCashBalance(findMember.getCashBalance() - actualAmount);
 
-                        // 포트폴리오 업데이트
-                        portfoliosService.updateForBuy(
-                                memberId, stockCode, stockName, quantity, currentPrice);
-                        return OrderResponseDto.builder()
-                                .executed(true)
-                                .message("지정가 매수 즉시 체결 완료")
-                                .price(currentPrice)
-                                .build();
-                    } else {
-                        // 대기 주문으로 등록
-                        ordersRepository.save(order);
+                portfoliosService.updateForBuy(memberId, stockCode, stockName, quantity, currentPrice);
 
-                        // 잔고 동결 (실제 거래소에서는 지정가 금액만큼 동결)
-                        findMember.setCashBalance(findMember.getCashBalance() - totalAmount);
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("지정가 매수 주문 대기중")
-                                .price(limitPrice)
-                                .build();
-                    }
-                });
+                log.info("지정가 매수 즉시 체결. memberId={}, stockCode={}, limitPrice={}, executedPrice={}, quantity={}",
+                        memberId, stockCode, limitPrice, currentPrice, quantity);
+
+                return OrderResponseDto.builder()
+                        .executed(true)
+                        .message("지정가 매수 즉시 체결 완료")
+                        .price(currentPrice)
+                        .build();
+            } else {
+                // 대기 주문으로 등록
+                ordersRepository.save(order);
+                findMember.setCashBalance(findMember.getCashBalance() - totalAmount);
+
+                log.info("지정가 매수 주문 대기. memberId={}, stockCode={}, limitPrice={}, currentPrice={}, quantity={}",
+                        memberId, stockCode, limitPrice, currentPrice, quantity);
+
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("지정가 매수 주문 대기중")
+                        .price(limitPrice)
+                        .build();
+            }
+        });
     }
 
     @Transactional
     public OrderResponseDto executeLimitSellOrders(Long memberId, OrdersLimitTypeRequestDto dto) {
-        return executeWithStockLock(
-                dto.getStockCode(),
-                () -> {
-                    Members findMember =
-                            membersRepository
-                                    .findByIdWithLock(memberId)
-                                    .orElseThrow(() -> new NotFoundMemberException(memberId));
+        return executeWithStockSemaphore(dto.getStockCode(), () -> {
+            Members findMember =
+                    membersRepository
+                            .findByIdWithLock(memberId)
+                            .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-                    String stockCode = dto.getStockCode();
-                    String stockName = dto.getStockName();
-                    int limitPrice = dto.getPrice();
-                    int quantity = dto.getQuantity();
-                    int cashBalance = findMember.getCashBalance();
+            String stockCode = dto.getStockCode();
+            String stockName = dto.getStockName();
+            int limitPrice = dto.getPrice();
+            int quantity = dto.getQuantity();
+            int cashBalance = findMember.getCashBalance();
 
-                    Portfolios portfolio =
-                            portfoliosRepository
-                                    .findByMembersIdAndStockCodeWithLock(memberId, stockCode)
-                                    .orElseThrow(() -> new NotFoundPortfolioException());
+            Portfolios portfolio = portfoliosRepository.findByMembersIdAndStockCodeWithLock(memberId, stockCode)
+                    .orElseThrow(() -> new NotFoundPortfolioException());
 
-                    if (portfolio.getQuantity() < quantity) {
-                        throw new InvalidSellQuantityException(quantity);
-                    }
-                    Integer currentPrice = getCurrentPriceOrNull(stockCode);
-                    if (currentPrice == null) {
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("지정가 매도 실패: 현재 가격 정보를 불러올 수 없습니다.")
-                                .build();
-                    }
+            if (portfolio.getQuantity() < quantity) {
+                throw new InvalidSellQuantityException(quantity);
+            }
 
-                    Orders order =
-                            new Orders(
-                                    stockCode,
-                                    stockName,
-                                    OrderType.LIMIT,
-                                    TradeType.SELL,
-                                    quantity,
-                                    limitPrice,
-                                    findMember);
+            Integer currentPrice = getCurrentPriceOrNull(stockCode);
+            if (currentPrice == null) {
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("지정가 매도 실패: 현재 가격 정보를 불러올 수 없습니다.")
+                        .build();
+            }
 
-                    if (currentPrice >= limitPrice) {
-                        order.execute();
-                        ordersRepository.save(order);
+            Orders order = new Orders(stockCode, stockName, OrderType.LIMIT, TradeType.SELL, quantity, limitPrice, findMember);
 
-                        Trades trades =
-                                new Trades(
-                                        stockCode,
-                                        stockName,
-                                        TradeType.SELL,
-                                        quantity,
-                                        currentPrice,
-                                        findMember);
-                        tradesRepository.save(trades);
+            if (currentPrice >= limitPrice) {
+                order.execute();
+                ordersRepository.save(order);
 
-                        int actualAmount = currentPrice * quantity;
-                        findMember.setCashBalance(cashBalance + actualAmount);
+                Trades trades = new Trades(stockCode, stockName, TradeType.SELL, quantity, currentPrice, findMember);
+                tradesRepository.save(trades);
 
-                        portfoliosService.updateForSell(memberId, stockCode, quantity);
+                int actualAmount = currentPrice * quantity;
+                findMember.setCashBalance(cashBalance + actualAmount);
 
-                        return OrderResponseDto.builder()
-                                .executed(true)
-                                .message("지정가 매도 즉시 체결 완료")
-                                .price(currentPrice)
-                                .build();
-                    } else {
-                        ordersRepository.save(order);
+                portfoliosService.updateForSell(memberId, stockCode, quantity);
 
-                        portfoliosService.updateForSell(memberId, stockCode, quantity);
+                log.info("지정가 매도 즉시 체결. memberId={}, stockCode={}, limitPrice={}, executedPrice={}, quantity={}",
+                        memberId, stockCode, limitPrice, currentPrice, quantity);
 
-                        return OrderResponseDto.builder()
-                                .executed(false)
-                                .message("지정가 매도 주문 대기중")
-                                .price(limitPrice)
-                                .build();
-                    }
-                });
+                return OrderResponseDto.builder()
+                        .executed(true)
+                        .message("지정가 매도 즉시 체결 완료")
+                        .price(currentPrice)
+                        .build();
+            } else {
+                ordersRepository.save(order);
+                portfoliosService.updateForSell(memberId, stockCode, quantity);
+
+                log.info("지정가 매도 주문 대기. memberId={}, stockCode={}, limitPrice={}, currentPrice={}, quantity={}",
+                        memberId, stockCode, limitPrice, currentPrice, quantity);
+
+                return OrderResponseDto.builder()
+                        .executed(false)
+                        .message("지정가 매도 주문 대기중")
+                        .price(limitPrice)
+                        .build();
+            }
+        });
     }
 
     private Integer getCurrentPriceOrNull(String stockCode) {
@@ -388,7 +325,7 @@ public class OrdersService {
                         .findById(memberId)
                         .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-        ordersRepository.deleteByMembersId(memberId);
+        ordersRepository.deleteByMembersId(findMember.getId());
     }
 
     public boolean openKoreanMarket() {

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/VirtualThreadConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/VirtualThreadConfig.java
@@ -1,0 +1,23 @@
+package io.gaboja9.mockstock.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class VirtualThreadConfig {
+
+    @Bean
+    @Primary
+    public TaskScheduler virtualThreadTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadFactory(Thread.ofVirtual().name("virtual-scheduler-").factory());
+        scheduler.setPoolSize(50);
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/MockStock/src/main/resources/application-local.yml
+++ b/MockStock/src/main/resources/application-local.yml
@@ -79,11 +79,24 @@ spring:
   autoconfigure:
     exclude: org.springframework.boot.actuate.autoconfigure.metrics.export.influx.InfluxMetricsExportAutoConfiguration
 
+  threads:
+    virtual:
+      enabled: true
+
+  task:
+    scheduling:
+      pool:
+        size: 20
+    execution:
+      pool:
+        core-size: 50
+        max-size: 200
+
 management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info,prometheus,threaddump
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## 관련 이슈
close #97 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->
## 개요
캐시 + 락 구조를 사용하여 대기 상태의 주문을 날짜순으로 순차적 처리하던 구조 대신
가상 스레드를 사용하여 모든 대기상태의 주문을 병렬로 처리합니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

