### PR TITLE
refactor : 멤버정보와 포트폴리오 조회 시 손익, 수익률을 계산하는 로직 수정

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/dto/response/MemberInfoDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/dto/response/MemberInfoDto.java
@@ -15,11 +15,11 @@ public class MemberInfoDto {
     @Schema(description = "프로필 이미지")
     private String profileImage;
 
-    @Schema(description = "총 손익")
-    private double totalProfit;
+    @Schema(description = "수익률")
+    private double totalProfitRate;
 
-    @Schema(description = "총 평가금액")
-    private int totalEvaluationAmount;
+    @Schema(description = "총 자산")
+    private int totalCashBalance;
 
     @Schema(description = "총 거래 횟수")
     private int tradeCnt;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/entity/Members.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/entity/Members.java
@@ -34,6 +34,8 @@ public class Members extends BaseEntity {
 
     @Setter private int cashBalance = 30_000_000;
 
+    @Setter private int totalInvestedAmount = 0;
+
     @Setter private int bankruptcyCnt;
 
     @Setter private String memo;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/service/MembersService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/service/MembersService.java
@@ -38,7 +38,7 @@ public class MembersService {
                         .orElseThrow(() -> new NotFoundMemberException(memberId));
 
         int tradeCnt = tradesRepository.countByMembersId(memberId);
-        // int ranking = ranksService.getRankByMemberId(memberId); // TODO : 랭킹 로직 개발되면 추가
+        int ranking = ranksService.getMemberReturnRateRank(memberId);
         int period =
                 (int) ChronoUnit.DAYS.between(member.getCreatedAt().toLocalDate(), LocalDate.now());
         int bankruptcyCnt = member.getBankruptcyCnt();
@@ -49,7 +49,7 @@ public class MembersService {
                 .totalProfit(portfolios.getTotalProfit())
                 .totalEvaluationAmount(portfolios.getTotalEvaluationAmount())
                 .tradeCnt(tradeCnt)
-                // .ranking(ranking)
+                .ranking(ranking)
                 .period(period)
                 .bankruptcyCnt(bankruptcyCnt)
                 .build();

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/service/MembersService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/members/service/MembersService.java
@@ -46,11 +46,11 @@ public class MembersService {
         return MemberInfoDto.builder()
                 .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
-                .totalProfit(portfolios.getTotalProfit())
-                .totalEvaluationAmount(portfolios.getTotalEvaluationAmount())
+                .totalProfitRate(portfolios.getTotalProfitRate())
+                .totalCashBalance(portfolios.getTotalEvaluationAmount() + member.getCashBalance())
                 .tradeCnt(tradeCnt)
                 .ranking(ranking)
-                .period(period)
+                .period(period + 1)
                 .bankruptcyCnt(bankruptcyCnt)
                 .build();
     }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/service/KakaoPayService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/service/KakaoPayService.java
@@ -142,7 +142,9 @@ public class KakaoPayService {
             if (approveResponse != null) {
 
                 Members member = paymentHistory.getMembers();
-                member.setCashBalance(member.getCashBalance() + paymentHistory.getAmount());
+                int chargeAmount = paymentHistory.getAmount();
+                member.setTotalInvestedAmount(member.getTotalInvestedAmount() + chargeAmount);
+                member.setCashBalance(member.getCashBalance() + chargeAmount);
                 membersRepository.save(member);
 
                 paymentHistory.setStatus(PaymentStatus.APPROVED);

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
@@ -37,13 +37,18 @@ public class PortfoliosService {
             dtoList.add(portfoliosMapper.toDto(p));
         }
 
-        PortfoliosSummary summary = calculateSummary(dtoList);
+        Members member = membersRepository
+                .findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(memberId));
 
-        int cashBalance =
-                membersRepository
-                        .findById(memberId)
-                        .orElseThrow(() -> new NotFoundMemberException(memberId))
-                        .getCashBalance();
+        int cashBalance = member.getCashBalance();
+        int totalInvestedAmount = member.getTotalInvestedAmount(); // 총 투입 자금
+
+        if (totalInvestedAmount == 0) {
+            totalInvestedAmount = 30_000_000;
+        }
+
+        PortfoliosSummary summary = calculateSummary(dtoList, cashBalance, totalInvestedAmount);
 
         return PortfoliosResponseDto.builder()
                 .cashBalance(cashBalance)
@@ -54,24 +59,27 @@ public class PortfoliosService {
                 .build();
     }
 
-    public PortfoliosSummary calculateSummary(List<PortfolioResponseDto> dtoList) {
-        int totalEvaluationAmount = 0;
-        int totalProfit = 0;
-        int totalInvestment = 0;
+    public PortfoliosSummary calculateSummary(List<PortfolioResponseDto> dtoList, int cashBalance, int totalInvestedAmount) {
+        int totalStockEvaluationAmount = 0;
 
+        // 주식 포트폴리오 계산
         for (PortfolioResponseDto dto : dtoList) {
-            totalEvaluationAmount += dto.getEvaluationAmount();
-            totalProfit += dto.getProfit();
-            totalInvestment += dto.getAvgPrice() * dto.getQuantity();
+            totalStockEvaluationAmount += dto.getEvaluationAmount();
         }
 
-        double totalProfitRate =
-                totalInvestment == 0
-                        ? 0.00
-                        : Math.round((double) totalProfit / totalInvestment * 100 * 100) / 100.0;
+        int totalCurrentAssets = cashBalance + totalStockEvaluationAmount;
+
+        int totalProfit = totalCurrentAssets - totalInvestedAmount;
+
+        double totalProfitRate = 0;
+        if (totalInvestedAmount == 0) {
+            totalProfitRate = 0.00;
+        } else {
+            totalProfitRate = Math.round((double) totalProfit / totalInvestedAmount * 10000.0) / 100.0;
+        }
 
         return PortfoliosSummary.builder()
-                .totalEvaluationAmount(totalEvaluationAmount)
+                .totalEvaluationAmount(totalStockEvaluationAmount)
                 .totalProfit(totalProfit)
                 .totalProfitRate(totalProfitRate)
                 .build();

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosService.java
@@ -37,9 +37,10 @@ public class PortfoliosService {
             dtoList.add(portfoliosMapper.toDto(p));
         }
 
-        Members member = membersRepository
-                .findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(memberId));
+        Members member =
+                membersRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new NotFoundMemberException(memberId));
 
         int cashBalance = member.getCashBalance();
         int totalInvestedAmount = member.getTotalInvestedAmount(); // 총 투입 자금
@@ -59,7 +60,8 @@ public class PortfoliosService {
                 .build();
     }
 
-    public PortfoliosSummary calculateSummary(List<PortfolioResponseDto> dtoList, int cashBalance, int totalInvestedAmount) {
+    public PortfoliosSummary calculateSummary(
+            List<PortfolioResponseDto> dtoList, int cashBalance, int totalInvestedAmount) {
         int totalStockEvaluationAmount = 0;
 
         // 주식 포트폴리오 계산
@@ -75,7 +77,8 @@ public class PortfoliosService {
         if (totalInvestedAmount == 0) {
             totalProfitRate = 0.00;
         } else {
-            totalProfitRate = Math.round((double) totalProfit / totalInvestedAmount * 10000.0) / 100.0;
+            totalProfitRate =
+                    Math.round((double) totalProfit / totalInvestedAmount * 10000.0) / 100.0;
         }
 
         return PortfoliosSummary.builder()

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
@@ -294,4 +294,23 @@ public class RanksService {
         }
         return stockPrice.getCurrentPrice();
     }
+
+    public Integer getMemberReturnRateRank(Long memberId) {
+        String key = RANKING_KEY_PREFIX + RanksType.RETURN_RATE.name().toLowerCase();
+
+        @SuppressWarnings("unchecked")
+        List<RanksDto> cachedRanks = (List<RanksDto>) redisTemplate.opsForValue().get(key);
+
+        if (cachedRanks == null || cachedRanks.isEmpty()) {
+            log.warn("수익률 기준 캐시 랭킹이 없습니다. 실시간 계산을 수행합니다.");
+            cachedRanks = calculateRealTimeRankingList(RanksType.RETURN_RATE);
+        }
+
+        return cachedRanks.stream()
+                .filter(ranking -> ranking.getMemberId().equals(memberId))
+                .findFirst()
+                .map(RanksDto::getRank)
+                .orElse(null);
+    }
+
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
@@ -312,5 +312,4 @@ public class RanksService {
                 .map(RanksDto::getRank)
                 .orElse(null);
     }
-
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/ranks/service/RanksService.java
@@ -217,7 +217,7 @@ public class RanksService {
         long totalProfit = totalAsset - totalInvestment;
 
         double returnRate =
-                totalInvestment > 0 ? ((double) totalProfit / totalInvestment) + 100 : 0.0;
+                totalInvestment > 0 ? ((double) totalProfit / totalInvestment) * 100 : 0.0;
 
         return RanksDto.builder()
                 .memberId(member.getId())

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/members/service/MembersServiceTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/members/service/MembersServiceTest.java
@@ -79,10 +79,10 @@ class MembersServiceTest {
         // then
         assertThat(result.getNickname()).isEqualTo("testUser");
         assertThat(result.getProfileImage()).isEqualTo("test.png");
-        assertThat(result.getTotalProfit()).isEqualTo(10000);
-        assertThat(result.getTotalEvaluationAmount()).isEqualTo(50000);
+        assertThat(result.getTotalProfitRate()).isEqualTo(0.0);
+        assertThat(result.getTotalCashBalance()).isEqualTo(55000);
         assertThat(result.getTradeCnt()).isEqualTo(5);
-        assertThat(result.getPeriod()).isEqualTo(15);
+        assertThat(result.getPeriod()).isEqualTo(16);
         assertThat(result.getBankruptcyCnt()).isEqualTo(0);
     }
 

--- a/MockStock/src/test/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosServiceTest.java
+++ b/MockStock/src/test/java/io/gaboja9/mockstock/domain/portfolios/service/PortfoliosServiceTest.java
@@ -87,7 +87,8 @@ class PortfoliosServiceTest {
         given(portfoliosMapper.toDto(p2)).willReturn(dto2);
         given(membersRepository.findById(memberId)).willReturn(Optional.of(member));
 
-        int totalStockEvaluationAmount = dto1.getEvaluationAmount() + dto2.getEvaluationAmount(); // 2700
+        int totalStockEvaluationAmount =
+                dto1.getEvaluationAmount() + dto2.getEvaluationAmount(); // 2700
         int cashBalance = member.getCashBalance(); // 30000000
         int totalInvestedAmount = member.getTotalInvestedAmount(); // 30000000
 
@@ -99,7 +100,8 @@ class PortfoliosServiceTest {
 
         int expectedTotalProfit = totalCurrentAssets - totalInvestedAmount;
 
-        double expectedTotalProfitRate = Math.round((double) expectedTotalProfit / totalInvestedAmount * 10000.0) / 100.0;
+        double expectedTotalProfitRate =
+                Math.round((double) expectedTotalProfit / totalInvestedAmount * 10000.0) / 100.0;
 
         PortfoliosResponseDto result = portfoliosService.getPortfolios(memberId);
 


### PR DESCRIPTION
## 관련 이슈
close #117 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->
## 개요
기존 코드에서 보유중인 주식이 없을 경우 수익률과 손익이 0으로 계산되는 현상을 발견하여 수정하였습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

