### PR TITLE
refactor: 토큰 재발급 API 수정

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/controller/AuthController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/controller/AuthController.java
@@ -11,8 +11,8 @@ import io.gaboja9.mockstock.domain.auth.repository.TokenRepository;
 import io.gaboja9.mockstock.domain.auth.service.EmailVerificationService;
 import io.gaboja9.mockstock.domain.auth.service.FormAuthService;
 import io.gaboja9.mockstock.domain.auth.service.JwtTokenProvider;
-
 import io.gaboja9.mockstock.global.config.JwtConfiguration;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
@@ -24,8 +24,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -39,7 +37,6 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenRepository tokenRepository;
     private final JwtConfiguration jwtConfiguration;
-
 
     @PostMapping("/signup")
     public ResponseEntity<AuthResponseDto> signUp(
@@ -161,10 +158,11 @@ public class AuthController {
 
             Long accessTokenExpiresIn = jwtConfiguration.getValidation().getAccess() / 60000;
 
-            TokenRefreshResponseDto responseData = TokenRefreshResponseDto.builder()
-                    .accessToken(newAccessToken)
-                    .accessTokenExpiresIn(accessTokenExpiresIn)
-                    .build();
+            TokenRefreshResponseDto responseData =
+                    TokenRefreshResponseDto.builder()
+                            .accessToken(newAccessToken)
+                            .accessTokenExpiresIn(accessTokenExpiresIn)
+                            .build();
 
             return ResponseEntity.ok(AuthResponseDto.success("토큰 갱신이 완료되었습니다.", responseData));
 

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/TokenPair.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/TokenPair.java
@@ -13,4 +13,6 @@ public class TokenPair {
 
     private String accessToken;
     private String refreshToken;
+    private Long accessTokenExpiresIn;
+    private Long refreshTokenExpiresIn;
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/request/TokenRefreshRequestDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/request/TokenRefreshRequestDto.java
@@ -1,0 +1,19 @@
+package io.gaboja9.mockstock.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 갱신 요청")
+public class TokenRefreshRequestDto {
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+    @NotBlank(message = "리프레시 토큰을 입력해주세요")
+    private String refreshToken;
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/request/TokenRefreshRequestDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/request/TokenRefreshRequestDto.java
@@ -1,7 +1,9 @@
 package io.gaboja9.mockstock.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotBlank;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/response/TokenRefreshResponseDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/response/TokenRefreshResponseDto.java
@@ -1,0 +1,20 @@
+package io.gaboja9.mockstock.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 갱신 응답")
+public class TokenRefreshResponseDto {
+    @Schema(description = "새로운 액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+    private String accessToken;
+
+    @Schema(description = "액세스 토큰 만료시간 (분)", example = "60")
+    private Long accessTokenExpiresIn;
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/response/TokenRefreshResponseDto.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/dto/response/TokenRefreshResponseDto.java
@@ -1,6 +1,7 @@
 package io.gaboja9.mockstock.domain.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/TokenRepository.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/TokenRepository.java
@@ -5,6 +5,7 @@ import io.gaboja9.mockstock.domain.auth.entity.RefreshToken;
 import io.gaboja9.mockstock.domain.auth.entity.RefreshTokenBlackList;
 import io.gaboja9.mockstock.domain.members.entity.Members;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TokenRepository {
@@ -17,4 +18,6 @@ public interface TokenRepository {
     Optional<RefreshToken> findValidRefreshToken(Long memberId);
 
     boolean isTokenBlacklisted(String token);
+
+    List<RefreshToken> findAllValidRefreshTokens(Long memberId);
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/adapter/RefreshTokenRepositoryAdapter.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/adapter/RefreshTokenRepositoryAdapter.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -83,5 +84,20 @@ public class RefreshTokenRepositoryAdapter implements TokenRepository {
                 .createQuery(jpql, Boolean.class)
                 .setParameter("token", token)
                 .getSingleResult();
+    }
+
+    @Override
+    public List<RefreshToken> findAllValidRefreshTokens(Long membersId) {
+        String jpql =
+                """
+        select rf from RefreshToken rf
+        left join RefreshTokenBlackList rtb on rtb.refreshToken = rf
+        where rf.members.id = :membersId and rtb.id is null
+    """;
+
+        return entityManager
+                .createQuery(jpql, RefreshToken.class)
+                .setParameter("membersId", membersId)
+                .getResultList();
     }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/adapter/RefreshTokenRepositoryAdapter.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/repository/adapter/RefreshTokenRepositoryAdapter.java
@@ -90,10 +90,10 @@ public class RefreshTokenRepositoryAdapter implements TokenRepository {
     public List<RefreshToken> findAllValidRefreshTokens(Long membersId) {
         String jpql =
                 """
-        select rf from RefreshToken rf
-        left join RefreshTokenBlackList rtb on rtb.refreshToken = rf
-        where rf.members.id = :membersId and rtb.id is null
-    """;
+                    select rf from RefreshToken rf
+                    left join RefreshTokenBlackList rtb on rtb.refreshToken = rf
+                    where rf.members.id = :membersId and rtb.id is null
+                """;
 
         return entityManager
                 .createQuery(jpql, RefreshToken.class)

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/service/JwtTokenProvider.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/service/JwtTokenProvider.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import javax.crypto.SecretKey;
@@ -36,13 +37,23 @@ public class JwtTokenProvider {
     private final TokenRepository tokenRepository;
 
     public TokenPair generateTokenPair(Members members) {
-
         String acceessToken = issueAcceessToken(members.getId(), members.getRole());
         String refreshToken = issueRefreshToken(members.getId(), members.getRole());
 
+        List<RefreshToken> existingTokens = tokenRepository.findAllValidRefreshTokens(members.getId());
+        for (RefreshToken existingToken : existingTokens) {
+            tokenRepository.addBlackList(existingToken);
+            log.info("기존 RefreshToken 무효화: 사용자 ID {}", members.getId());
+        }
+
         tokenRepository.save(members, refreshToken);
 
-        return TokenPair.builder().accessToken(acceessToken).refreshToken(refreshToken).build();
+        return TokenPair.builder()
+                .accessToken(acceessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiresIn(jwtConfiguration.getValidation().getAccess() / 60000)
+                .refreshTokenExpiresIn(jwtConfiguration.getValidation().getRefresh() / 60000)
+                .build();
     }
 
     public Optional<RefreshToken> findRefreshToken(Long membersId) {

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/service/JwtTokenProvider.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/auth/service/JwtTokenProvider.java
@@ -40,7 +40,8 @@ public class JwtTokenProvider {
         String acceessToken = issueAcceessToken(members.getId(), members.getRole());
         String refreshToken = issueRefreshToken(members.getId(), members.getRole());
 
-        List<RefreshToken> existingTokens = tokenRepository.findAllValidRefreshTokens(members.getId());
+        List<RefreshToken> existingTokens =
+                tokenRepository.findAllValidRefreshTokens(members.getId());
         for (RefreshToken existingToken : existingTokens) {
             tokenRepository.addBlackList(existingToken);
             log.info("기존 RefreshToken 무효화: 사용자 ID {}", members.getId());

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/controller/KakaoPayController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/payments/controller/KakaoPayController.java
@@ -38,11 +38,9 @@ public class KakaoPayController implements KakaoPayControllerSpec {
 
     @GetMapping("/approve")
     public ResponseEntity<PaymentResponse> paymentApprove(
-            @RequestParam("pg_token") String pgToken,
-            @RequestParam("member_id") Long memberId) {
+            @RequestParam("pg_token") String pgToken, @RequestParam("member_id") Long memberId) {
         try {
-            KakaoPayApproveResponse response =
-                    kakaoPayService.paymentApprove(pgToken, memberId);
+            KakaoPayApproveResponse response = kakaoPayService.paymentApprove(pgToken, memberId);
 
             return ResponseEntity.ok(PaymentResponse.success("결제 승인 완료", response));
 
@@ -54,8 +52,7 @@ public class KakaoPayController implements KakaoPayControllerSpec {
 
     @GetMapping("/cancel")
     public ResponseEntity<PaymentResponse> paymentCancel(
-            @RequestParam("tid") String tid,
-            @RequestParam("member_id") Long memberId) {
+            @RequestParam("tid") String tid, @RequestParam("member_id") Long memberId) {
         try {
             kakaoPayService.paymentCancel(tid, memberId);
 
@@ -69,8 +66,7 @@ public class KakaoPayController implements KakaoPayControllerSpec {
 
     @GetMapping("/fail")
     public ResponseEntity<PaymentResponse> paymentFail(
-            @RequestParam("tid") String tid,
-            @RequestParam("member_id") Long memberId) {
+            @RequestParam("tid") String tid, @RequestParam("member_id") Long memberId) {
         try {
             kakaoPayService.paymentFail(tid, memberId);
 


### PR DESCRIPTION
## 관련 이슈
#130 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

## 개요
JWT RefreshToken 갱신 API 개선 및 토큰 관리 로직 최적화
- RefreshToken 갱신 API를 요청 바디 방식으로 변경
- 로그인 시 기존 RefreshToken 무효화 로직 추가
- 토큰 만료시간 정보를 클라이언트에 제공
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->