### PR TITLE
bug : 배포 환경에서 Swagger가 api 요청을 http로 하는 버그 수정

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOrigins(List.of("https://mock-stock.pages.dev", "http://localhost:3000"));
 
         configuration.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("https://mock-stock.pages.dev", "http://localhost:3000"));
+        configuration.setAllowedOrigins(
+                List.of("https://mock-stock.pages.dev", "http://localhost:3000"));
 
         configuration.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SwaggerConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SwaggerConfig.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
-
 import io.swagger.v3.oas.annotations.servers.Server;
+
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -70,8 +70,8 @@ import org.springframework.context.annotation.Configuration;
                                 - 모든 에러는 `/user/queue/errors`로 수신
                                 """),
         servers = {
-                @Server(url = "https://mockstocks.duckdns.org", description = "배포용"),
-                @Server(url = "http://localhost:8080", description = "개발용")
+            @Server(url = "https://mockstocks.duckdns.org", description = "배포용"),
+            @Server(url = "http://localhost:8080", description = "개발용")
         },
         security = @SecurityRequirement(name = "bearerAuth"))
 @SecurityScheme(

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SwaggerConfig.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/config/SwaggerConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -68,6 +69,10 @@ import org.springframework.context.annotation.Configuration;
                                 - 심각한 오류 발생 시 자동 연결 종료
                                 - 모든 에러는 `/user/queue/errors`로 수신
                                 """),
+        servers = {
+                @Server(url = "https://mockstocks.duckdns.org", description = "배포용"),
+                @Server(url = "http://localhost:8080", description = "개발용")
+        },
         security = @SecurityRequirement(name = "bearerAuth"))
 @SecurityScheme(
         name = "bearerAuth",


### PR DESCRIPTION
## 관련 이슈
close #132 
<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->
## 개요
배포 환경에서 Swagger로 api 요청 시 https가 아닌 http로 요청을 보내서 500 응답이 내려오던 현상을 수정합니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

