### PR TITLE
refactor : 5분봉 조회 저장 리팩토링 , MockStock컨트롤러 리팩토링

### DIFF
--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/controller/StocksController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/controller/StocksController.java
@@ -1,23 +1,21 @@
 package io.gaboja9.mockstock.domain.stock.controller;
 
 import io.gaboja9.mockstock.domain.stock.dto.StockResponse;
+import io.gaboja9.mockstock.domain.stock.service.FiveMinuteAggregationService;
 import io.gaboja9.mockstock.domain.stock.service.StocksBulkService;
 import io.gaboja9.mockstock.domain.stock.service.StocksDataService;
 import io.gaboja9.mockstock.domain.stock.service.StocksMinuteService;
 import io.gaboja9.mockstock.domain.stock.service.StocksService;
 import io.gaboja9.mockstock.domain.stock.service.TodayMinuteStockService;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 // 주식 데이터 수집을 위한 컨트롤러
 @Slf4j
@@ -26,126 +24,144 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StocksController implements StocksControllerSpec {
 
-    private final StocksDataService stockDataService;
-    private final StocksMinuteService stocksMinuteService;
-    private final TodayMinuteStockService todayMinuteStockService;
-    private final StocksService stocksService;
-    private final StocksBulkService stocksBulkService;
+  private final StocksDataService stockDataService;
+  private final StocksMinuteService stocksMinuteService;
+  private final TodayMinuteStockService todayMinuteStockService;
+  private final StocksService stocksService;
+  private final StocksBulkService stocksBulkService;
+  private final FiveMinuteAggregationService fiveMinuteAggregationService;
 
-    @GetMapping("/long-term-daily")
-    public ResponseEntity<?> fetchLongTermDailyStockData(
-            @RequestParam(defaultValue = "J") String marketCode,
-            @RequestParam String stockCode,
-            @RequestParam String startDate,
-            @RequestParam String endDate,
-            @RequestParam(defaultValue = "D") String periodCode) {
 
-        log.info("장기간 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
-        try {
-            stockDataService.fetchAndSaveLongTermData(
-                    marketCode, stockCode, startDate, endDate, periodCode);
-            String resultMessage =
-                    String.format(
-                            "장기간 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
-                            stockCode, startDate, endDate);
-            return ResponseEntity.ok(resultMessage);
-        } catch (Exception e) {
-            log.error("장기간 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("장기간 데이터 수집 실패: " + e.getMessage());
-        }
+  @GetMapping("/long-term-daily")
+  public ResponseEntity<?> fetchLongTermDailyStockData(
+      @RequestParam(defaultValue = "J") String marketCode,
+      @RequestParam String stockCode,
+      @RequestParam String startDate,
+      @RequestParam String endDate,
+      @RequestParam(defaultValue = "D") String periodCode) {
+
+    log.info("장기간 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+    try {
+      stockDataService.fetchAndSaveLongTermData(
+          marketCode, stockCode, startDate, endDate, periodCode);
+      String resultMessage =
+          String.format(
+              "장기간 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
+              stockCode, startDate, endDate);
+      return ResponseEntity.ok(resultMessage);
+    } catch (Exception e) {
+      log.error("장기간 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body("장기간 데이터 수집 실패: " + e.getMessage());
     }
+  }
 
-    @GetMapping("/long-term-minute")
-    public ResponseEntity<?> fetchLongTermMinuteStockData(
-            @RequestParam(defaultValue = "J") String marketCode,
-            @RequestParam String stockCode,
-            @RequestParam String startDate,
-            @RequestParam String endDate,
-            @RequestParam(defaultValue = "Y") String includePastData) {
+  @GetMapping("/long-term-minute")
+  public ResponseEntity<?> fetchLongTermMinuteStockData(
+      @RequestParam(defaultValue = "J") String marketCode,
+      @RequestParam String stockCode,
+      @RequestParam String startDate,
+      @RequestParam String endDate,
+      @RequestParam(defaultValue = "Y") String includePastData) {
 
-        log.info("장기간 분봉 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+    log.info("장기간 분봉 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
 
-        try {
+    try {
 
-            stocksMinuteService.fetchAndSaveLongTermMinuteData(
-                    marketCode, stockCode, startDate, endDate, includePastData);
+      stocksMinuteService.fetchAndSaveLongTermMinuteData(
+          marketCode, stockCode, startDate, endDate, includePastData);
 
-            String resultMessage =
-                    String.format(
-                            "장기간 분봉 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
-                            stockCode, startDate, endDate);
+      String resultMessage =
+          String.format(
+              "장기간 분봉 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
+              stockCode, startDate, endDate);
 
-            return ResponseEntity.ok(resultMessage);
+      return ResponseEntity.ok(resultMessage);
 
-        } catch (Exception e) {
-            log.error("장기간 분봉 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("장기간 분봉 데이터 수집 실패: " + e.getMessage());
-        }
+    } catch (Exception e) {
+      log.error("장기간 분봉 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body("장기간 분봉 데이터 수집 실패: " + e.getMessage());
     }
+  }
 
-    @GetMapping("/fetch-data")
-    public ResponseEntity<?> fetchStockData(
-            @RequestParam String marketCode, //  주식 J
-            @RequestParam String stockCode, //  단일 종목 코드
-            @RequestParam String startDate,
-            @RequestParam String endDate,
-            @RequestParam String periodCode) {
+  @GetMapping("/fetch-data")
+  public ResponseEntity<?> fetchStockData(
+      @RequestParam String marketCode, //  주식 J
+      @RequestParam String stockCode, //  단일 종목 코드
+      @RequestParam String startDate,
+      @RequestParam String endDate,
+      @RequestParam String periodCode) {
 
-        log.info("주식 데이터 수집 요청: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+    log.info("주식 데이터 수집 요청: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
 
-        // 단일 종목 처리용 서비스 호출
-        stockDataService.fetchAndSaveData(marketCode, stockCode, startDate, endDate, periodCode);
+    // 단일 종목 처리용 서비스 호출
+    stockDataService.fetchAndSaveData(marketCode, stockCode, startDate, endDate, periodCode);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(" 주식 저장 완료");
+    return ResponseEntity.status(HttpStatus.CREATED).body(" 주식 저장 완료");
+  }
+
+  @GetMapping("/minute-data")
+  public ResponseEntity<?> mStockData(
+      @RequestParam String marketCode,
+      @RequestParam String stockCode,
+      @RequestParam String startHour,
+      @RequestParam String date,
+      @RequestParam String includePastData) {
+    stocksMinuteService.fetchAndSaveMinuteData(
+        marketCode, stockCode, date, startHour, includePastData);
+    return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
+  }
+
+  @GetMapping("/today-minute-data")
+  public ResponseEntity<?> minuteStockData(
+      @RequestParam String marketCode,
+      @RequestParam String stockCode,
+      @RequestParam String startTime,
+      @RequestParam String includePastData,
+      @RequestParam String clsCode) {
+
+    todayMinuteStockService.fetchAndSaveCurrentDayMinuteData(
+        marketCode, stockCode, startTime, includePastData, clsCode);
+    return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
+  }
+
+  @GetMapping()
+  public ResponseEntity<List<StockResponse>> getAllStocks() {
+    return ResponseEntity.ok(stocksService.getAllStocks());
+  }
+
+  // 전체 주식 데이터 수집 (일봉+주봉+월봉 2년11개월 + 분봉 7일)
+  @Override
+  @GetMapping("/bulk/all-data")
+  public ResponseEntity<String> fetchAllStocksAllData(
+      @RequestParam(defaultValue = "J") String marketCode) {
+
+    log.info("전체 주식 모든 데이터 수집 요청 시작");
+
+    try {
+      stocksBulkService.fetchAllStocksAllData(marketCode);
+      return ResponseEntity.status(HttpStatus.CREATED).body("데이터 수집 작업 시작됨");
+
+    } catch (Exception e) {
+      log.error("데이터 수집 시작 실패", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("데이터 수집 시작 실패");
     }
+  }
 
-    @GetMapping("/minute-data")
-    public ResponseEntity<?> mStockData(
-            @RequestParam String marketCode,
-            @RequestParam String stockCode,
-            @RequestParam String startHour,
-            @RequestParam String date,
-            @RequestParam String includePastData) {
-        stocksMinuteService.fetchAndSaveMinuteData(
-                marketCode, stockCode, date, startHour, includePastData);
-        return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
+
+  @GetMapping("/five-minute/all")
+  public ResponseEntity<String> aggregateAllStocksToFiveMinute() {
+
+    log.info("전체 종목 5분봉 집계 요청 시작");
+
+    try {
+      fiveMinuteAggregationService.aggregateAllStocksToFiveMinute();
+      return ResponseEntity.status(HttpStatus.CREATED).body("5분봉 집계 작업 시작됨");
+
+    } catch (Exception e) {
+      log.error("5분봉 집계 시작 실패", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("5분봉 집계 시작 실패");
     }
-
-    @GetMapping("/today-minute-data")
-    public ResponseEntity<?> minuteStockData(
-            @RequestParam String marketCode,
-            @RequestParam String stockCode,
-            @RequestParam String startTime,
-            @RequestParam String includePastData,
-            @RequestParam String clsCode) {
-
-        todayMinuteStockService.fetchAndSaveCurrentDayMinuteData(
-                marketCode, stockCode, startTime, includePastData, clsCode);
-        return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
-    }
-
-    @GetMapping()
-    public ResponseEntity<List<StockResponse>> getAllStocks() {
-        return ResponseEntity.ok(stocksService.getAllStocks());
-    }
-
-    // 전체 주식 데이터 수집 (일봉+주봉+월봉 2년11개월 + 분봉 7일)
-    @Override
-    @GetMapping("/bulk/all-data")
-    public ResponseEntity<String> fetchAllStocksAllData(
-            @RequestParam(defaultValue = "J") String marketCode) {
-
-        log.info("전체 주식 모든 데이터 수집 요청 시작");
-
-        try {
-            stocksBulkService.fetchAllStocksAllData(marketCode);
-            return ResponseEntity.status(HttpStatus.CREATED).body("데이터 수집 작업 시작됨");
-
-        } catch (Exception e) {
-            log.error("데이터 수집 시작 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("데이터 수집 시작 실패");
-        }
-    }
+  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/controller/StocksController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/controller/StocksController.java
@@ -7,15 +7,18 @@ import io.gaboja9.mockstock.domain.stock.service.StocksDataService;
 import io.gaboja9.mockstock.domain.stock.service.StocksMinuteService;
 import io.gaboja9.mockstock.domain.stock.service.StocksService;
 import io.gaboja9.mockstock.domain.stock.service.TodayMinuteStockService;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 // 주식 데이터 수집을 위한 컨트롤러
 @Slf4j
@@ -24,144 +27,142 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class StocksController implements StocksControllerSpec {
 
-  private final StocksDataService stockDataService;
-  private final StocksMinuteService stocksMinuteService;
-  private final TodayMinuteStockService todayMinuteStockService;
-  private final StocksService stocksService;
-  private final StocksBulkService stocksBulkService;
-  private final FiveMinuteAggregationService fiveMinuteAggregationService;
+    private final StocksDataService stockDataService;
+    private final StocksMinuteService stocksMinuteService;
+    private final TodayMinuteStockService todayMinuteStockService;
+    private final StocksService stocksService;
+    private final StocksBulkService stocksBulkService;
+    private final FiveMinuteAggregationService fiveMinuteAggregationService;
 
+    @GetMapping("/long-term-daily")
+    public ResponseEntity<?> fetchLongTermDailyStockData(
+            @RequestParam(defaultValue = "J") String marketCode,
+            @RequestParam String stockCode,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam(defaultValue = "D") String periodCode) {
 
-  @GetMapping("/long-term-daily")
-  public ResponseEntity<?> fetchLongTermDailyStockData(
-      @RequestParam(defaultValue = "J") String marketCode,
-      @RequestParam String stockCode,
-      @RequestParam String startDate,
-      @RequestParam String endDate,
-      @RequestParam(defaultValue = "D") String periodCode) {
-
-    log.info("장기간 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
-    try {
-      stockDataService.fetchAndSaveLongTermData(
-          marketCode, stockCode, startDate, endDate, periodCode);
-      String resultMessage =
-          String.format(
-              "장기간 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
-              stockCode, startDate, endDate);
-      return ResponseEntity.ok(resultMessage);
-    } catch (Exception e) {
-      log.error("장기간 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body("장기간 데이터 수집 실패: " + e.getMessage());
+        log.info("장기간 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+        try {
+            stockDataService.fetchAndSaveLongTermData(
+                    marketCode, stockCode, startDate, endDate, periodCode);
+            String resultMessage =
+                    String.format(
+                            "장기간 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
+                            stockCode, startDate, endDate);
+            return ResponseEntity.ok(resultMessage);
+        } catch (Exception e) {
+            log.error("장기간 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("장기간 데이터 수집 실패: " + e.getMessage());
+        }
     }
-  }
 
-  @GetMapping("/long-term-minute")
-  public ResponseEntity<?> fetchLongTermMinuteStockData(
-      @RequestParam(defaultValue = "J") String marketCode,
-      @RequestParam String stockCode,
-      @RequestParam String startDate,
-      @RequestParam String endDate,
-      @RequestParam(defaultValue = "Y") String includePastData) {
+    @GetMapping("/long-term-minute")
+    public ResponseEntity<?> fetchLongTermMinuteStockData(
+            @RequestParam(defaultValue = "J") String marketCode,
+            @RequestParam String stockCode,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam(defaultValue = "Y") String includePastData) {
 
-    log.info("장기간 분봉 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+        log.info("장기간 분봉 데이터 수집 요청 접수: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
 
-    try {
+        try {
 
-      stocksMinuteService.fetchAndSaveLongTermMinuteData(
-          marketCode, stockCode, startDate, endDate, includePastData);
+            stocksMinuteService.fetchAndSaveLongTermMinuteData(
+                    marketCode, stockCode, startDate, endDate, includePastData);
 
-      String resultMessage =
-          String.format(
-              "장기간 분봉 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
-              stockCode, startDate, endDate);
+            String resultMessage =
+                    String.format(
+                            "장기간 분봉 데이터 수집 작업 성공적으로 위임: %s, 기간: %s ~ %s",
+                            stockCode, startDate, endDate);
 
-      return ResponseEntity.ok(resultMessage);
+            return ResponseEntity.ok(resultMessage);
 
-    } catch (Exception e) {
-      log.error("장기간 분봉 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body("장기간 분봉 데이터 수집 실패: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("장기간 분봉 데이터 수집 중 컨트롤러 레벨 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("장기간 분봉 데이터 수집 실패: " + e.getMessage());
+        }
     }
-  }
 
-  @GetMapping("/fetch-data")
-  public ResponseEntity<?> fetchStockData(
-      @RequestParam String marketCode, //  주식 J
-      @RequestParam String stockCode, //  단일 종목 코드
-      @RequestParam String startDate,
-      @RequestParam String endDate,
-      @RequestParam String periodCode) {
+    @GetMapping("/fetch-data")
+    public ResponseEntity<?> fetchStockData(
+            @RequestParam String marketCode, //  주식 J
+            @RequestParam String stockCode, //  단일 종목 코드
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam String periodCode) {
 
-    log.info("주식 데이터 수집 요청: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
+        log.info("주식 데이터 수집 요청: {}, 기간: {} ~ {}", stockCode, startDate, endDate);
 
-    // 단일 종목 처리용 서비스 호출
-    stockDataService.fetchAndSaveData(marketCode, stockCode, startDate, endDate, periodCode);
+        // 단일 종목 처리용 서비스 호출
+        stockDataService.fetchAndSaveData(marketCode, stockCode, startDate, endDate, periodCode);
 
-    return ResponseEntity.status(HttpStatus.CREATED).body(" 주식 저장 완료");
-  }
-
-  @GetMapping("/minute-data")
-  public ResponseEntity<?> mStockData(
-      @RequestParam String marketCode,
-      @RequestParam String stockCode,
-      @RequestParam String startHour,
-      @RequestParam String date,
-      @RequestParam String includePastData) {
-    stocksMinuteService.fetchAndSaveMinuteData(
-        marketCode, stockCode, date, startHour, includePastData);
-    return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
-  }
-
-  @GetMapping("/today-minute-data")
-  public ResponseEntity<?> minuteStockData(
-      @RequestParam String marketCode,
-      @RequestParam String stockCode,
-      @RequestParam String startTime,
-      @RequestParam String includePastData,
-      @RequestParam String clsCode) {
-
-    todayMinuteStockService.fetchAndSaveCurrentDayMinuteData(
-        marketCode, stockCode, startTime, includePastData, clsCode);
-    return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
-  }
-
-  @GetMapping()
-  public ResponseEntity<List<StockResponse>> getAllStocks() {
-    return ResponseEntity.ok(stocksService.getAllStocks());
-  }
-
-  // 전체 주식 데이터 수집 (일봉+주봉+월봉 2년11개월 + 분봉 7일)
-  @Override
-  @GetMapping("/bulk/all-data")
-  public ResponseEntity<String> fetchAllStocksAllData(
-      @RequestParam(defaultValue = "J") String marketCode) {
-
-    log.info("전체 주식 모든 데이터 수집 요청 시작");
-
-    try {
-      stocksBulkService.fetchAllStocksAllData(marketCode);
-      return ResponseEntity.status(HttpStatus.CREATED).body("데이터 수집 작업 시작됨");
-
-    } catch (Exception e) {
-      log.error("데이터 수집 시작 실패", e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("데이터 수집 시작 실패");
+        return ResponseEntity.status(HttpStatus.CREATED).body(" 주식 저장 완료");
     }
-  }
 
-
-  @GetMapping("/five-minute/all")
-  public ResponseEntity<String> aggregateAllStocksToFiveMinute() {
-
-    log.info("전체 종목 5분봉 집계 요청 시작");
-
-    try {
-      fiveMinuteAggregationService.aggregateAllStocksToFiveMinute();
-      return ResponseEntity.status(HttpStatus.CREATED).body("5분봉 집계 작업 시작됨");
-
-    } catch (Exception e) {
-      log.error("5분봉 집계 시작 실패", e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("5분봉 집계 시작 실패");
+    @GetMapping("/minute-data")
+    public ResponseEntity<?> mStockData(
+            @RequestParam String marketCode,
+            @RequestParam String stockCode,
+            @RequestParam String startHour,
+            @RequestParam String date,
+            @RequestParam String includePastData) {
+        stocksMinuteService.fetchAndSaveMinuteData(
+                marketCode, stockCode, date, startHour, includePastData);
+        return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
     }
-  }
+
+    @GetMapping("/today-minute-data")
+    public ResponseEntity<?> minuteStockData(
+            @RequestParam String marketCode,
+            @RequestParam String stockCode,
+            @RequestParam String startTime,
+            @RequestParam String includePastData,
+            @RequestParam String clsCode) {
+
+        todayMinuteStockService.fetchAndSaveCurrentDayMinuteData(
+                marketCode, stockCode, startTime, includePastData, clsCode);
+        return ResponseEntity.status(HttpStatus.CREATED).body("분 주식 저장 완료");
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<StockResponse>> getAllStocks() {
+        return ResponseEntity.ok(stocksService.getAllStocks());
+    }
+
+    // 전체 주식 데이터 수집 (일봉+주봉+월봉 2년11개월 + 분봉 7일)
+    @Override
+    @GetMapping("/bulk/all-data")
+    public ResponseEntity<String> fetchAllStocksAllData(
+            @RequestParam(defaultValue = "J") String marketCode) {
+
+        log.info("전체 주식 모든 데이터 수집 요청 시작");
+
+        try {
+            stocksBulkService.fetchAllStocksAllData(marketCode);
+            return ResponseEntity.status(HttpStatus.CREATED).body("데이터 수집 작업 시작됨");
+
+        } catch (Exception e) {
+            log.error("데이터 수집 시작 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("데이터 수집 시작 실패");
+        }
+    }
+
+    @GetMapping("/five-minute/all")
+    public ResponseEntity<String> aggregateAllStocksToFiveMinute() {
+
+        log.info("전체 종목 5분봉 집계 요청 시작");
+
+        try {
+            fiveMinuteAggregationService.aggregateAllStocksToFiveMinute();
+            return ResponseEntity.status(HttpStatus.CREATED).body("5분봉 집계 작업 시작됨");
+
+        } catch (Exception e) {
+            log.error("5분봉 집계 시작 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("5분봉 집계 시작 실패");
+        }
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/repository/StocksFiveMinuteRepository.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/repository/StocksFiveMinuteRepository.java
@@ -2,120 +2,158 @@ package io.gaboja9.mockstock.domain.stock.repository;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.QueryApi;
-
+import com.influxdb.client.WriteApi;
+import com.influxdb.client.write.Point;
 import io.gaboja9.mockstock.domain.stock.measurement.MinuteStockPrice;
-
+import java.time.Instant;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
-import java.time.Instant;
-import java.util.List;
-
 @Slf4j
 @Repository
-public class StocksFiveMinuteRepository { // 클래스 이름을 5분봉용으로 명확하게 구분
+public class StocksFiveMinuteRepository {
 
-    private final InfluxDBClient minuteInfluxDBClient;
+  private final InfluxDBClient minuteInfluxDBClient;
 
-    // StocksMinuteRepository와 동일한 버킷을 사용
-    @Value("${spring.influx.bucket.minute}")
-    private String minuteBucket;
+  @Value("${spring.influx.bucket.minute}")
+  private String minuteBucket;
 
-    public StocksFiveMinuteRepository(
-            @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
-        this.minuteInfluxDBClient = minuteInfluxDBClient;
+  @Value("${spring.influx.org}")
+  private String influxOrg;
+
+  public StocksFiveMinuteRepository(
+      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+    this.minuteInfluxDBClient = minuteInfluxDBClient;
+  }
+
+  /**
+   * 가장 최근의 5분봉 데이터를 조회합니다.
+   *
+   * @param stockCode 종목 코드
+   * @param limit     조회할 데이터 개수
+   * @return 5분봉 데이터 리스트
+   */
+  public List<MinuteStockPrice> findLatestFiveMinutePrices(String stockCode, int limit) {
+    // 5분봉 데이터는 변동성이 크므로 최근 30일 범위로 조회
+    String flux =
+        String.format(
+            """
+                from(bucket: "%s")
+                  |> range(start: -30d)
+                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
+                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                  |> rename(columns: {_time: "timestamp"})
+                  |> sort(columns: ["timestamp"], desc: true)
+                  |> limit(n: %d)
+                """,
+            minuteBucket, stockCode, limit);
+    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+    return queryApi.query(flux, MinuteStockPrice.class);
+  }
+
+  /**
+   * 특정 시점 이전의 5분봉 데이터를 추가로 조회합니다. (과거 데이터 로딩)
+   *
+   * @param stockCode       종목 코드
+   * @param beforeTimestamp 기준 시점
+   * @param limit           조회할 데이터 개수
+   * @return 5분봉 데이터 리스트
+   */
+  public List<MinuteStockPrice> findFiveMinutePricesBefore(
+      String stockCode, Instant beforeTimestamp, int limit) {
+    String flux =
+        String.format(
+            """
+                from(bucket: "%s")
+                  |> range(start: -30d, stop: time(v: "%s"))
+                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
+                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                  |> rename(columns: {_time: "timestamp"})
+                  |> sort(columns: ["timestamp"], desc: true)
+                  |> limit(n: %d)
+                """,
+            minuteBucket, beforeTimestamp.toString(), stockCode, limit);
+    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+    return queryApi.query(flux, MinuteStockPrice.class);
+  }
+
+  /**
+   * 특정 시점 이후의 5분봉 데이터를 추가로 조회합니다. (실시간 업데이트)
+   *
+   * @param stockCode      종목 코드
+   * @param afterTimestamp 기준 시점
+   * @param limit          조회할 데이터 개수
+   * @return 5분봉 데이터 리스트
+   */
+  public List<MinuteStockPrice> findFiveMinutePricesAfter(
+      String stockCode, Instant afterTimestamp, int limit) {
+    String flux =
+        String.format(
+            """
+                from(bucket: "%s")
+                  |> range(start: time(v: "%s"))
+                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s" and r._time > time(v: "%s"))
+                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                  |> rename(columns: {_time: "timestamp"})
+                  |> sort(columns: ["timestamp"], desc: false)
+                  |> limit(n: %d)
+                """,
+            minuteBucket,
+            afterTimestamp.toString(),
+            stockCode,
+            afterTimestamp.toString(),
+            limit);
+    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+    return queryApi.query(flux, MinuteStockPrice.class);
+  }
+
+
+  /**
+   * 1분봉을 5분봉으로 집계해서 조회
+   */
+  public List<MinuteStockPrice> getAggregatedFiveMinuteData(String stockCode) {
+    String flux = String.format("""
+        // 1. 1분봉 데이터 조회 (최근 1주일)
+        data_1m = from(bucket: "%s")
+          |> range(start: -7d)
+          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
+
+        // 2. 각 필드별로 5분 단위 집계
+        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
+        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
+        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
+        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
+        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
+
+        // 3. 집계된 데이터들을 합치고 MinuteStockPrice 형태로 반환
+        union(tables: [open, high, low, close, volume])
+          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+          |> rename(columns: {_time: "timestamp"})
+          |> sort(columns: ["timestamp"], desc: false)
+        """, minuteBucket, stockCode);
+
+    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+    return queryApi.query(flux, MinuteStockPrice.class);
+  }
+
+  /**
+   * 5분봉 데이터를 InfluxDB에 저장
+   */
+  public void saveFiveMinuteData(List<Point> points) {
+    if (points == null || points.isEmpty()) {
+      log.warn("저장할 5분봉 데이터가 없습니다.");
+      return;
     }
 
-    /** 가장 최근의 5분봉 데이터를 조회합니다. (1분봉을 5분봉으로 집계) */
-    public List<MinuteStockPrice> findLatestFiveMinutePrices(String stockCode, int limit) {
-        String flux =
-                String.format(
-                        """
-                        // 1. 1분봉 데이터 조회
-                        data_1m = from(bucket: "%s")
-                          |> range(start: -30d)
-                          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
-
-                        // 2. 각 필드별로 5분 단위 집계
-                        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
-                        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
-                        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
-                        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
-                        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
-
-                        // 3. 집계된 데이터들을 하나로 합치고 객체에 매핑
-                        union(tables: [open, high, low, close, volume])
-                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                          |> rename(columns: {_time: "timestamp"})
-                          |> sort(columns: ["timestamp"], desc: true)
-                          |> limit(n: %d)
-                        """,
-                        minuteBucket, stockCode, limit);
-        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-        return queryApi.query(flux, MinuteStockPrice.class);
+    try (WriteApi writeApi = minuteInfluxDBClient.getWriteApi()) {
+      writeApi.writePoints(minuteBucket, influxOrg, points);
+      log.debug("5분봉 데이터 {}개 포인트 저장 완료", points.size());
+    } catch (Exception e) {
+      log.error("5분봉 데이터 저장 중 오류 발생", e);
+      throw new RuntimeException("5분봉 데이터 저장 실패", e);
     }
-
-    /** 특정 시점 이전의 5분봉 데이터를 추가로 조회합니다. (1분봉을 5분봉으로 집계) */
-    public List<MinuteStockPrice> findFiveMinutePricesBefore(
-            String stockCode, Instant beforeTimestamp, int limit) {
-        String flux =
-                String.format(
-                        """
-                        data_1m = from(bucket: "%s")
-                          |> range(start: -30d, stop: time(v: "%s"))
-                          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
-
-                        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
-                        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
-                        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
-                        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
-                        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
-
-                        union(tables: [open, high, low, close, volume])
-                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                          |> rename(columns: {_time: "timestamp"})
-                          |> sort(columns: ["timestamp"], desc: true)
-                          |> limit(n: %d)
-                        """,
-                        minuteBucket, beforeTimestamp.toString(), stockCode, limit);
-        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-        return queryApi.query(flux, MinuteStockPrice.class);
-    }
-
-    /** 특정 시점 이후의 5분봉 데이터를 추가로 조회합니다. (1분봉을 5분봉으로 집계) */
-    public List<MinuteStockPrice> findFiveMinutePricesAfter(
-            String stockCode, Instant afterTimestamp, int limit) {
-        String flux =
-                String.format(
-                        """
-                        import "experimental"
-
-                        data_1m = from(bucket: "%s")
-                          |> range(start: experimental.subDuration(d: 5m, from: time(v: "%s")))
-                          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
-
-                        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
-                        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
-                        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
-                        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
-                        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
-
-                        union(tables: [open, high, low, close, volume])
-                          |> filter(fn: (r) => r._time > time(v: "%s"))
-                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                          |> rename(columns: {_time: "timestamp"})
-                          |> sort(columns: ["timestamp"], desc: false)
-                          |> limit(n: %d)
-                        """,
-                        minuteBucket,
-                        afterTimestamp.toString(),
-                        stockCode,
-                        afterTimestamp.toString(),
-                        limit);
-        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-        return queryApi.query(flux, MinuteStockPrice.class);
-    }
+  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/repository/StocksFiveMinuteRepository.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/repository/StocksFiveMinuteRepository.java
@@ -4,156 +4,158 @@ import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.QueryApi;
 import com.influxdb.client.WriteApi;
 import com.influxdb.client.write.Point;
+
 import io.gaboja9.mockstock.domain.stock.measurement.MinuteStockPrice;
-import java.time.Instant;
-import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
 
 @Slf4j
 @Repository
 public class StocksFiveMinuteRepository {
 
-  private final InfluxDBClient minuteInfluxDBClient;
+    private final InfluxDBClient minuteInfluxDBClient;
 
-  @Value("${spring.influx.bucket.minute}")
-  private String minuteBucket;
+    @Value("${spring.influx.bucket.minute}")
+    private String minuteBucket;
 
-  @Value("${spring.influx.org}")
-  private String influxOrg;
+    @Value("${spring.influx.org}")
+    private String influxOrg;
 
-  public StocksFiveMinuteRepository(
-      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
-    this.minuteInfluxDBClient = minuteInfluxDBClient;
-  }
-
-  /**
-   * 가장 최근의 5분봉 데이터를 조회합니다.
-   *
-   * @param stockCode 종목 코드
-   * @param limit     조회할 데이터 개수
-   * @return 5분봉 데이터 리스트
-   */
-  public List<MinuteStockPrice> findLatestFiveMinutePrices(String stockCode, int limit) {
-    // 5분봉 데이터는 변동성이 크므로 최근 30일 범위로 조회
-    String flux =
-        String.format(
-            """
-                from(bucket: "%s")
-                  |> range(start: -30d)
-                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
-                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                  |> rename(columns: {_time: "timestamp"})
-                  |> sort(columns: ["timestamp"], desc: true)
-                  |> limit(n: %d)
-                """,
-            minuteBucket, stockCode, limit);
-    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-    return queryApi.query(flux, MinuteStockPrice.class);
-  }
-
-  /**
-   * 특정 시점 이전의 5분봉 데이터를 추가로 조회합니다. (과거 데이터 로딩)
-   *
-   * @param stockCode       종목 코드
-   * @param beforeTimestamp 기준 시점
-   * @param limit           조회할 데이터 개수
-   * @return 5분봉 데이터 리스트
-   */
-  public List<MinuteStockPrice> findFiveMinutePricesBefore(
-      String stockCode, Instant beforeTimestamp, int limit) {
-    String flux =
-        String.format(
-            """
-                from(bucket: "%s")
-                  |> range(start: -30d, stop: time(v: "%s"))
-                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
-                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                  |> rename(columns: {_time: "timestamp"})
-                  |> sort(columns: ["timestamp"], desc: true)
-                  |> limit(n: %d)
-                """,
-            minuteBucket, beforeTimestamp.toString(), stockCode, limit);
-    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-    return queryApi.query(flux, MinuteStockPrice.class);
-  }
-
-  /**
-   * 특정 시점 이후의 5분봉 데이터를 추가로 조회합니다. (실시간 업데이트)
-   *
-   * @param stockCode      종목 코드
-   * @param afterTimestamp 기준 시점
-   * @param limit          조회할 데이터 개수
-   * @return 5분봉 데이터 리스트
-   */
-  public List<MinuteStockPrice> findFiveMinutePricesAfter(
-      String stockCode, Instant afterTimestamp, int limit) {
-    String flux =
-        String.format(
-            """
-                from(bucket: "%s")
-                  |> range(start: time(v: "%s"))
-                  |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s" and r._time > time(v: "%s"))
-                  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-                  |> rename(columns: {_time: "timestamp"})
-                  |> sort(columns: ["timestamp"], desc: false)
-                  |> limit(n: %d)
-                """,
-            minuteBucket,
-            afterTimestamp.toString(),
-            stockCode,
-            afterTimestamp.toString(),
-            limit);
-    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-    return queryApi.query(flux, MinuteStockPrice.class);
-  }
-
-
-  /**
-   * 1분봉을 5분봉으로 집계해서 조회
-   */
-  public List<MinuteStockPrice> getAggregatedFiveMinuteData(String stockCode) {
-    String flux = String.format("""
-        // 1. 1분봉 데이터 조회 (최근 1주일)
-        data_1m = from(bucket: "%s")
-          |> range(start: -7d)
-          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
-
-        // 2. 각 필드별로 5분 단위 집계
-        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
-        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
-        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
-        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
-        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
-
-        // 3. 집계된 데이터들을 합치고 MinuteStockPrice 형태로 반환
-        union(tables: [open, high, low, close, volume])
-          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
-          |> rename(columns: {_time: "timestamp"})
-          |> sort(columns: ["timestamp"], desc: false)
-        """, minuteBucket, stockCode);
-
-    QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
-    return queryApi.query(flux, MinuteStockPrice.class);
-  }
-
-  /**
-   * 5분봉 데이터를 InfluxDB에 저장
-   */
-  public void saveFiveMinuteData(List<Point> points) {
-    if (points == null || points.isEmpty()) {
-      log.warn("저장할 5분봉 데이터가 없습니다.");
-      return;
+    public StocksFiveMinuteRepository(
+            @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+        this.minuteInfluxDBClient = minuteInfluxDBClient;
     }
 
-    try (WriteApi writeApi = minuteInfluxDBClient.getWriteApi()) {
-      writeApi.writePoints(minuteBucket, influxOrg, points);
-      log.debug("5분봉 데이터 {}개 포인트 저장 완료", points.size());
-    } catch (Exception e) {
-      log.error("5분봉 데이터 저장 중 오류 발생", e);
-      throw new RuntimeException("5분봉 데이터 저장 실패", e);
+    /**
+     * 가장 최근의 5분봉 데이터를 조회합니다.
+     *
+     * @param stockCode 종목 코드
+     * @param limit 조회할 데이터 개수
+     * @return 5분봉 데이터 리스트
+     */
+    public List<MinuteStockPrice> findLatestFiveMinutePrices(String stockCode, int limit) {
+        // 5분봉 데이터는 변동성이 크므로 최근 30일 범위로 조회
+        String flux =
+                String.format(
+                        """
+                        from(bucket: "%s")
+                          |> range(start: -30d)
+                          |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
+                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                          |> rename(columns: {_time: "timestamp"})
+                          |> sort(columns: ["timestamp"], desc: true)
+                          |> limit(n: %d)
+                        """,
+                        minuteBucket, stockCode, limit);
+        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+        return queryApi.query(flux, MinuteStockPrice.class);
     }
-  }
+
+    /**
+     * 특정 시점 이전의 5분봉 데이터를 추가로 조회합니다. (과거 데이터 로딩)
+     *
+     * @param stockCode 종목 코드
+     * @param beforeTimestamp 기준 시점
+     * @param limit 조회할 데이터 개수
+     * @return 5분봉 데이터 리스트
+     */
+    public List<MinuteStockPrice> findFiveMinutePricesBefore(
+            String stockCode, Instant beforeTimestamp, int limit) {
+        String flux =
+                String.format(
+                        """
+                        from(bucket: "%s")
+                          |> range(start: -30d, stop: time(v: "%s"))
+                          |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s")
+                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                          |> rename(columns: {_time: "timestamp"})
+                          |> sort(columns: ["timestamp"], desc: true)
+                          |> limit(n: %d)
+                        """,
+                        minuteBucket, beforeTimestamp.toString(), stockCode, limit);
+        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+        return queryApi.query(flux, MinuteStockPrice.class);
+    }
+
+    /**
+     * 특정 시점 이후의 5분봉 데이터를 추가로 조회합니다. (실시간 업데이트)
+     *
+     * @param stockCode 종목 코드
+     * @param afterTimestamp 기준 시점
+     * @param limit 조회할 데이터 개수
+     * @return 5분봉 데이터 리스트
+     */
+    public List<MinuteStockPrice> findFiveMinutePricesAfter(
+            String stockCode, Instant afterTimestamp, int limit) {
+        String flux =
+                String.format(
+                        """
+                        from(bucket: "%s")
+                          |> range(start: time(v: "%s"))
+                          |> filter(fn: (r) => r._measurement == "stock_5minute" and r.stockCode == "%s" and r._time > time(v: "%s"))
+                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                          |> rename(columns: {_time: "timestamp"})
+                          |> sort(columns: ["timestamp"], desc: false)
+                          |> limit(n: %d)
+                        """,
+                        minuteBucket,
+                        afterTimestamp.toString(),
+                        stockCode,
+                        afterTimestamp.toString(),
+                        limit);
+        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+        return queryApi.query(flux, MinuteStockPrice.class);
+    }
+
+    /** 1분봉을 5분봉으로 집계해서 조회 */
+    public List<MinuteStockPrice> getAggregatedFiveMinuteData(String stockCode) {
+        String flux =
+                String.format(
+                        """
+                        // 1. 1분봉 데이터 조회 (최근 1주일)
+                        data_1m = from(bucket: "%s")
+                          |> range(start: -7d)
+                          |> filter(fn: (r) => r._measurement == "stock_minute" and r.stockCode == "%s")
+
+                        // 2. 각 필드별로 5분 단위 집계
+                        open = data_1m |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first, createEmpty: false)
+                        high = data_1m |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max, createEmpty: false)
+                        low = data_1m |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min, createEmpty: false)
+                        close = data_1m |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last, createEmpty: false)
+                        volume = data_1m |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum, createEmpty: false)
+
+                        // 3. 집계된 데이터들을 합치고 MinuteStockPrice 형태로 반환
+                        union(tables: [open, high, low, close, volume])
+                          |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+                          |> rename(columns: {_time: "timestamp"})
+                          |> sort(columns: ["timestamp"], desc: false)
+                        """,
+                        minuteBucket, stockCode);
+
+        QueryApi queryApi = minuteInfluxDBClient.getQueryApi();
+        return queryApi.query(flux, MinuteStockPrice.class);
+    }
+
+    /** 5분봉 데이터를 InfluxDB에 저장 */
+    public void saveFiveMinuteData(List<Point> points) {
+        if (points == null || points.isEmpty()) {
+            log.warn("저장할 5분봉 데이터가 없습니다.");
+            return;
+        }
+
+        try (WriteApi writeApi = minuteInfluxDBClient.getWriteApi()) {
+            writeApi.writePoints(minuteBucket, influxOrg, points);
+            log.debug("5분봉 데이터 {}개 포인트 저장 완료", points.size());
+        } catch (Exception e) {
+            log.error("5분봉 데이터 저장 중 오류 발생", e);
+            throw new RuntimeException("5분봉 데이터 저장 실패", e);
+        }
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/service/FiveMinuteAggregationService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/service/FiveMinuteAggregationService.java
@@ -1,0 +1,83 @@
+package io.gaboja9.mockstock.domain.stock.service;
+
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import io.gaboja9.mockstock.domain.stock.dto.StockResponse;
+import io.gaboja9.mockstock.domain.stock.measurement.MinuteStockPrice;
+import io.gaboja9.mockstock.domain.stock.repository.StocksFiveMinuteRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FiveMinuteAggregationService {
+
+  private final StocksFiveMinuteRepository fiveMinuteRepository;
+  private final StocksService stocksService;
+
+  /**
+   * 모든 종목의 최근 1주일치 데이터를 5분봉으로 집계해서 저장
+   */
+  public void aggregateAllStocksToFiveMinute() {
+    new Thread(() -> {
+      try {
+        log.info("전체 종목 5분봉 집계 작업 시작");
+
+        // 모든 종목 조회
+        List<StockResponse> allStocks = stocksService.getAllStocks();
+        log.info("집계 대상 종목 수: {}", allStocks.size());
+
+        int totalAggregated = 0;
+        for (StockResponse stock : allStocks) {
+          try {
+            int count = aggregateStockToFiveMinute(stock.getStockCode());
+            totalAggregated += count;
+            log.debug("종목 {} 집계 완료: {}개", stock.getStockCode(), count);
+          } catch (Exception e) {
+            log.error("종목 {} 집계 중 오류", stock.getStockCode(), e);
+          }
+        }
+
+        log.info("전체 종목 5분봉 집계 작업 완료: 총 {}개 데이터 생성", totalAggregated);
+
+      } catch (Exception e) {
+        log.error("전체 종목 집계 작업 중 오류 발생", e);
+      }
+    }).start();
+  }
+
+  /**
+   * 특정 종목의 1분봉을 5분봉으로 집계해서 저장
+   */
+  private int aggregateStockToFiveMinute(String stockCode) {
+    // 1. 리포지토리에서 집계된 데이터 조회
+    List<MinuteStockPrice> fiveMinuteData = fiveMinuteRepository.getAggregatedFiveMinuteData(
+        stockCode);
+
+    if (fiveMinuteData.isEmpty()) {
+      log.warn("집계할 1분봉 데이터가 없습니다 - 종목: {}", stockCode);
+      return 0;
+    }
+
+    // 2. MinuteStockPrice를 Point로 변환
+    List<Point> points = fiveMinuteData.stream()
+        .map(data -> Point.measurement("stock_5minute")
+            .addTag("stockCode", stockCode)
+            .addField("openPrice", data.getOpenPrice())
+            .addField("closePrice", data.getClosePrice())
+            .addField("maxPrice", data.getMaxPrice())
+            .addField("minPrice", data.getMinPrice())
+            .addField("accumTrans", data.getAccumTrans())
+            .time(data.getTimestamp(), WritePrecision.MS))
+        .toList();
+
+    // 3. 리포지토리에 저장
+    fiveMinuteRepository.saveFiveMinuteData(points);
+
+    log.info("5분봉 집계 및 저장 완료 - 종목: {}, {}개 포인트", stockCode, points.size());
+    return points.size();
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/service/FiveMinuteAggregationService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/domain/stock/service/FiveMinuteAggregationService.java
@@ -2,82 +2,88 @@ package io.gaboja9.mockstock.domain.stock.service;
 
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
+
 import io.gaboja9.mockstock.domain.stock.dto.StockResponse;
 import io.gaboja9.mockstock.domain.stock.measurement.MinuteStockPrice;
 import io.gaboja9.mockstock.domain.stock.repository.StocksFiveMinuteRepository;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FiveMinuteAggregationService {
 
-  private final StocksFiveMinuteRepository fiveMinuteRepository;
-  private final StocksService stocksService;
+    private final StocksFiveMinuteRepository fiveMinuteRepository;
+    private final StocksService stocksService;
 
-  /**
-   * 모든 종목의 최근 1주일치 데이터를 5분봉으로 집계해서 저장
-   */
-  public void aggregateAllStocksToFiveMinute() {
-    new Thread(() -> {
-      try {
-        log.info("전체 종목 5분봉 집계 작업 시작");
+    /** 모든 종목의 최근 1주일치 데이터를 5분봉으로 집계해서 저장 */
+    public void aggregateAllStocksToFiveMinute() {
+        new Thread(
+                        () -> {
+                            try {
+                                log.info("전체 종목 5분봉 집계 작업 시작");
 
-        // 모든 종목 조회
-        List<StockResponse> allStocks = stocksService.getAllStocks();
-        log.info("집계 대상 종목 수: {}", allStocks.size());
+                                // 모든 종목 조회
+                                List<StockResponse> allStocks = stocksService.getAllStocks();
+                                log.info("집계 대상 종목 수: {}", allStocks.size());
 
-        int totalAggregated = 0;
-        for (StockResponse stock : allStocks) {
-          try {
-            int count = aggregateStockToFiveMinute(stock.getStockCode());
-            totalAggregated += count;
-            log.debug("종목 {} 집계 완료: {}개", stock.getStockCode(), count);
-          } catch (Exception e) {
-            log.error("종목 {} 집계 중 오류", stock.getStockCode(), e);
-          }
-        }
+                                int totalAggregated = 0;
+                                for (StockResponse stock : allStocks) {
+                                    try {
+                                        int count =
+                                                aggregateStockToFiveMinute(stock.getStockCode());
+                                        totalAggregated += count;
+                                        log.debug("종목 {} 집계 완료: {}개", stock.getStockCode(), count);
+                                    } catch (Exception e) {
+                                        log.error("종목 {} 집계 중 오류", stock.getStockCode(), e);
+                                    }
+                                }
 
-        log.info("전체 종목 5분봉 집계 작업 완료: 총 {}개 데이터 생성", totalAggregated);
+                                log.info("전체 종목 5분봉 집계 작업 완료: 총 {}개 데이터 생성", totalAggregated);
 
-      } catch (Exception e) {
-        log.error("전체 종목 집계 작업 중 오류 발생", e);
-      }
-    }).start();
-  }
-
-  /**
-   * 특정 종목의 1분봉을 5분봉으로 집계해서 저장
-   */
-  private int aggregateStockToFiveMinute(String stockCode) {
-    // 1. 리포지토리에서 집계된 데이터 조회
-    List<MinuteStockPrice> fiveMinuteData = fiveMinuteRepository.getAggregatedFiveMinuteData(
-        stockCode);
-
-    if (fiveMinuteData.isEmpty()) {
-      log.warn("집계할 1분봉 데이터가 없습니다 - 종목: {}", stockCode);
-      return 0;
+                            } catch (Exception e) {
+                                log.error("전체 종목 집계 작업 중 오류 발생", e);
+                            }
+                        })
+                .start();
     }
 
-    // 2. MinuteStockPrice를 Point로 변환
-    List<Point> points = fiveMinuteData.stream()
-        .map(data -> Point.measurement("stock_5minute")
-            .addTag("stockCode", stockCode)
-            .addField("openPrice", data.getOpenPrice())
-            .addField("closePrice", data.getClosePrice())
-            .addField("maxPrice", data.getMaxPrice())
-            .addField("minPrice", data.getMinPrice())
-            .addField("accumTrans", data.getAccumTrans())
-            .time(data.getTimestamp(), WritePrecision.MS))
-        .toList();
+    /** 특정 종목의 1분봉을 5분봉으로 집계해서 저장 */
+    private int aggregateStockToFiveMinute(String stockCode) {
+        // 1. 리포지토리에서 집계된 데이터 조회
+        List<MinuteStockPrice> fiveMinuteData =
+                fiveMinuteRepository.getAggregatedFiveMinuteData(stockCode);
 
-    // 3. 리포지토리에 저장
-    fiveMinuteRepository.saveFiveMinuteData(points);
+        if (fiveMinuteData.isEmpty()) {
+            log.warn("집계할 1분봉 데이터가 없습니다 - 종목: {}", stockCode);
+            return 0;
+        }
 
-    log.info("5분봉 집계 및 저장 완료 - 종목: {}, {}개 포인트", stockCode, points.size());
-    return points.size();
-  }
+        // 2. MinuteStockPrice를 Point로 변환
+        List<Point> points =
+                fiveMinuteData.stream()
+                        .map(
+                                data ->
+                                        Point.measurement("stock_5minute")
+                                                .addTag("stockCode", stockCode)
+                                                .addField("openPrice", data.getOpenPrice())
+                                                .addField("closePrice", data.getClosePrice())
+                                                .addField("maxPrice", data.getMaxPrice())
+                                                .addField("minPrice", data.getMinPrice())
+                                                .addField("accumTrans", data.getAccumTrans())
+                                                .time(data.getTimestamp(), WritePrecision.MS))
+                        .toList();
+
+        // 3. 리포지토리에 저장
+        fiveMinuteRepository.saveFiveMinuteData(points);
+
+        log.info("5분봉 집계 및 저장 완료 - 종목: {}, {}개 포인트", stockCode, points.size());
+        return points.size();
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/DailyTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/DailyTaskInitializer.java
@@ -4,159 +4,161 @@ import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.TasksApi;
 import com.influxdb.client.domain.Task;
 import com.influxdb.client.domain.TaskStatusType;
+
 import jakarta.annotation.PostConstruct;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
 public class DailyTaskInitializer {
 
-  @Value("${spring.influx.org}")
-  private String influxOrg;
+    @Value("${spring.influx.org}")
+    private String influxOrg;
 
-  @Value("${spring.influx.bucket.minute}")
-  private String minuteBucket;
+    @Value("${spring.influx.bucket.minute}")
+    private String minuteBucket;
 
-  @Value("${spring.influx.bucket.daily}")
-  private String dailyBucket;
+    @Value("${spring.influx.bucket.daily}")
+    private String dailyBucket;
 
-  private static final String TASK_NAME = "1분봉 to 일봉 변환 작업";
+    private static final String TASK_NAME = "1분봉 to 일봉 변환 작업";
 
-  private final InfluxDBClient minuteInfluxDBClient;
+    private final InfluxDBClient minuteInfluxDBClient;
 
-  public DailyTaskInitializer(
-      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
-    this.minuteInfluxDBClient = minuteInfluxDBClient;
-  }
-
-  @PostConstruct
-  public void initializeDailyFromMinuteTask() {
-    TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
-
-    try {
-      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
-
-      if (existingTask.isPresent()) {
-        Task task = existingTask.get();
-        log.info(
-            "Daily-from-minute task '{}' already exists (ID: {}, Status: {})",
-            TASK_NAME,
-            task.getId(),
-            task.getStatus());
-
-        if (task.getStatus() == TaskStatusType.INACTIVE) {
-          task.setStatus(TaskStatusType.ACTIVE);
-          tasksApi.updateTask(task);
-          log.info("Activated daily-from-minute task '{}'", TASK_NAME);
-        }
-      } else {
-        createNewTask(tasksApi);
-      }
-
-    } catch (Exception e) {
-      log.error("Failed to initialize daily-from-minute task '{}'", TASK_NAME, e);
+    public DailyTaskInitializer(
+            @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+        this.minuteInfluxDBClient = minuteInfluxDBClient;
     }
-  }
 
-  private void createNewTask(TasksApi tasksApi) {
-    log.info("Creating new daily-from-minute task: {}", TASK_NAME);
+    @PostConstruct
+    public void initializeDailyFromMinuteTask() {
+        TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
 
-    Task newTask = new Task();
-    newTask.setName(TASK_NAME);
-    newTask.setOrg(influxOrg);
-    newTask.setStatus(TaskStatusType.ACTIVE);
-    newTask.setDescription("매일 오후 6시에 1분봉 데이터를 일봉으로 변환하여 daily 버킷에 저장");
-    newTask.setFlux(generateFluxScript());
+        try {
+            Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
 
-    Task createdTask = tasksApi.createTask(newTask);
-    log.info(
-        "Successfully created daily-from-minute task '{}' with ID: {}",
-        TASK_NAME,
-        createdTask.getId());
-  }
+            if (existingTask.isPresent()) {
+                Task task = existingTask.get();
+                log.info(
+                        "Daily-from-minute task '{}' already exists (ID: {}, Status: {})",
+                        TASK_NAME,
+                        task.getId(),
+                        task.getStatus());
 
-  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
-    List<Task> tasks = tasksApi.findTasks();
-    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
-  }
+                if (task.getStatus() == TaskStatusType.INACTIVE) {
+                    task.setStatus(TaskStatusType.ACTIVE);
+                    tasksApi.updateTask(task);
+                    log.info("Activated daily-from-minute task '{}'", TASK_NAME);
+                }
+            } else {
+                createNewTask(tasksApi);
+            }
 
-
-  private String generateFluxScript() {
-    return String.format(
-        """
-        import "date"
-  
-        option task = {
-          name: "%s",
-          every: 1d,
-          // 수정: 18:00 KST는 09:00 UTC이므로 offset을 9h로 설정
-          offset: 9h
+        } catch (Exception e) {
+            log.error("Failed to initialize daily-from-minute task '{}'", TASK_NAME, e);
         }
-        // 오늘 00:00 UTC 부터 Task 실행 시점(18:00 KST)까지 조회
-        range_start = date.truncate(t: now(), unit: 1d)
-        range_stop = now()
-        
-        // minute 버킷에서 한국 장 시간(09:00 ~ 15:30) 데이터만 필터링
-        base = from(bucket: "%s")
-          |> range(start: range_start, stop: range_stop)
-          |> filter(fn: (r) => r._measurement == "stock_minute")
-          |> filter(fn: (r) => {
-              kst = date.add(d: 9h, to: r._time)
-              h = date.hour(t: kst)
-              m = date.minute(t: kst)
-              return (h >= 9 and h < 15) or (h == 15 and m <= 30)
-          })
-        // 타임스탬프를 해당일의 15:00 UTC로 설정하는 함수
-        setTimestampTo15UTC = (r) => {
-          // Task 실행 시간을 기준으로 날짜의 시작(00:00 UTC)을 구함
-          day_start_utc = date.truncate(t: now(), unit: 1d)
- 
-          return {
-            r with
-            _measurement: "stock_daily",
-            _time: date.add(d: 15h, to: day_start_utc)
-          }
-        }
-  
-        open = base
-          |> filter(fn: (r) => r._field == "openPrice")
-          |> aggregateWindow(every: 1d, fn: first)
-          |> map(fn: (r) => ({ r with _field: "openPrice" }))
-          |> map(fn: setTimestampTo15UTC)
-  
-        high = base
-          |> filter(fn: (r) => r._field == "maxPrice")
-          |> aggregateWindow(every: 1d, fn: max)
-          |> map(fn: (r) => ({ r with _field: "maxPrice" }))
-          |> map(fn: setTimestampTo15UTC)
-  
-        low = base
-          |> filter(fn: (r) => r._field == "minPrice")
-          |> aggregateWindow(every: 1d, fn: min)
-          |> map(fn: (r) => ({ r with _field: "minPrice" }))
-          |> map(fn: setTimestampTo15UTC)
-  
-        close = base
-          |> filter(fn: (r) => r._field == "closePrice")
-          |> aggregateWindow(every: 1d, fn: last)
-          |> map(fn: (r) => ({ r with _field: "closePrice" }))
-          |> map(fn: setTimestampTo15UTC)
-  
-        volume = base
-          |> filter(fn: (r) => r._field == "accumTrans")
-          |> aggregateWindow(every: 1d, fn: last)
-          |> map(fn: (r) => ({ r with _field: "accumTrans" }))
-          |> map(fn: setTimestampTo15UTC)
-  
-        union(tables: [open, high, low, close, volume])
-          |> to(bucket: "%s", org: "%s")
-        """,
-        TASK_NAME, minuteBucket, dailyBucket, influxOrg);
-  }
+    }
 
+    private void createNewTask(TasksApi tasksApi) {
+        log.info("Creating new daily-from-minute task: {}", TASK_NAME);
+
+        Task newTask = new Task();
+        newTask.setName(TASK_NAME);
+        newTask.setOrg(influxOrg);
+        newTask.setStatus(TaskStatusType.ACTIVE);
+        newTask.setDescription("매일 오후 6시에 1분봉 데이터를 일봉으로 변환하여 daily 버킷에 저장");
+        newTask.setFlux(generateFluxScript());
+
+        Task createdTask = tasksApi.createTask(newTask);
+        log.info(
+                "Successfully created daily-from-minute task '{}' with ID: {}",
+                TASK_NAME,
+                createdTask.getId());
+    }
+
+    private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+        List<Task> tasks = tasksApi.findTasks();
+        return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+    }
+
+    private String generateFluxScript() {
+        return String.format(
+                """
+                import "date"
+
+                option task = {
+                  name: "%s",
+                  every: 1d,
+                  // 수정: 18:00 KST는 09:00 UTC이므로 offset을 9h로 설정
+                  offset: 9h
+                }
+                // 오늘 00:00 UTC 부터 Task 실행 시점(18:00 KST)까지 조회
+                range_start = date.truncate(t: now(), unit: 1d)
+                range_stop = now()
+
+                // minute 버킷에서 한국 장 시간(09:00 ~ 15:30) 데이터만 필터링
+                base = from(bucket: "%s")
+                  |> range(start: range_start, stop: range_stop)
+                  |> filter(fn: (r) => r._measurement == "stock_minute")
+                  |> filter(fn: (r) => {
+                      kst = date.add(d: 9h, to: r._time)
+                      h = date.hour(t: kst)
+                      m = date.minute(t: kst)
+                      return (h >= 9 and h < 15) or (h == 15 and m <= 30)
+                  })
+                // 타임스탬프를 해당일의 15:00 UTC로 설정하는 함수
+                setTimestampTo15UTC = (r) => {
+                  // Task 실행 시간을 기준으로 날짜의 시작(00:00 UTC)을 구함
+                  day_start_utc = date.truncate(t: now(), unit: 1d)
+
+                  return {
+                    r with
+                    _measurement: "stock_daily",
+                    _time: date.add(d: 15h, to: day_start_utc)
+                  }
+                }
+
+                open = base
+                  |> filter(fn: (r) => r._field == "openPrice")
+                  |> aggregateWindow(every: 1d, fn: first)
+                  |> map(fn: (r) => ({ r with _field: "openPrice" }))
+                  |> map(fn: setTimestampTo15UTC)
+
+                high = base
+                  |> filter(fn: (r) => r._field == "maxPrice")
+                  |> aggregateWindow(every: 1d, fn: max)
+                  |> map(fn: (r) => ({ r with _field: "maxPrice" }))
+                  |> map(fn: setTimestampTo15UTC)
+
+                low = base
+                  |> filter(fn: (r) => r._field == "minPrice")
+                  |> aggregateWindow(every: 1d, fn: min)
+                  |> map(fn: (r) => ({ r with _field: "minPrice" }))
+                  |> map(fn: setTimestampTo15UTC)
+
+                close = base
+                  |> filter(fn: (r) => r._field == "closePrice")
+                  |> aggregateWindow(every: 1d, fn: last)
+                  |> map(fn: (r) => ({ r with _field: "closePrice" }))
+                  |> map(fn: setTimestampTo15UTC)
+
+                volume = base
+                  |> filter(fn: (r) => r._field == "accumTrans")
+                  |> aggregateWindow(every: 1d, fn: last)
+                  |> map(fn: (r) => ({ r with _field: "accumTrans" }))
+                  |> map(fn: setTimestampTo15UTC)
+
+                union(tables: [open, high, low, close, volume])
+                  |> to(bucket: "%s", org: "%s")
+                """,
+                TASK_NAME, minuteBucket, dailyBucket, influxOrg);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/DailyTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/DailyTaskInitializer.java
@@ -1,0 +1,162 @@
+package io.gaboja9.mockstock.global.influx;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.TasksApi;
+import com.influxdb.client.domain.Task;
+import com.influxdb.client.domain.TaskStatusType;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class DailyTaskInitializer {
+
+  @Value("${spring.influx.org}")
+  private String influxOrg;
+
+  @Value("${spring.influx.bucket.minute}")
+  private String minuteBucket;
+
+  @Value("${spring.influx.bucket.daily}")
+  private String dailyBucket;
+
+  private static final String TASK_NAME = "1분봉 to 일봉 변환 작업";
+
+  private final InfluxDBClient minuteInfluxDBClient;
+
+  public DailyTaskInitializer(
+      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+    this.minuteInfluxDBClient = minuteInfluxDBClient;
+  }
+
+  @PostConstruct
+  public void initializeDailyFromMinuteTask() {
+    TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
+
+    try {
+      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
+
+      if (existingTask.isPresent()) {
+        Task task = existingTask.get();
+        log.info(
+            "Daily-from-minute task '{}' already exists (ID: {}, Status: {})",
+            TASK_NAME,
+            task.getId(),
+            task.getStatus());
+
+        if (task.getStatus() == TaskStatusType.INACTIVE) {
+          task.setStatus(TaskStatusType.ACTIVE);
+          tasksApi.updateTask(task);
+          log.info("Activated daily-from-minute task '{}'", TASK_NAME);
+        }
+      } else {
+        createNewTask(tasksApi);
+      }
+
+    } catch (Exception e) {
+      log.error("Failed to initialize daily-from-minute task '{}'", TASK_NAME, e);
+    }
+  }
+
+  private void createNewTask(TasksApi tasksApi) {
+    log.info("Creating new daily-from-minute task: {}", TASK_NAME);
+
+    Task newTask = new Task();
+    newTask.setName(TASK_NAME);
+    newTask.setOrg(influxOrg);
+    newTask.setStatus(TaskStatusType.ACTIVE);
+    newTask.setDescription("매일 오후 6시에 1분봉 데이터를 일봉으로 변환하여 daily 버킷에 저장");
+    newTask.setFlux(generateFluxScript());
+
+    Task createdTask = tasksApi.createTask(newTask);
+    log.info(
+        "Successfully created daily-from-minute task '{}' with ID: {}",
+        TASK_NAME,
+        createdTask.getId());
+  }
+
+  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+    List<Task> tasks = tasksApi.findTasks();
+    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+  }
+
+
+  private String generateFluxScript() {
+    return String.format(
+        """
+        import "date"
+  
+        option task = {
+          name: "%s",
+          every: 1d,
+          // 수정: 18:00 KST는 09:00 UTC이므로 offset을 9h로 설정
+          offset: 9h
+        }
+        // 오늘 00:00 UTC 부터 Task 실행 시점(18:00 KST)까지 조회
+        range_start = date.truncate(t: now(), unit: 1d)
+        range_stop = now()
+        
+        // minute 버킷에서 한국 장 시간(09:00 ~ 15:30) 데이터만 필터링
+        base = from(bucket: "%s")
+          |> range(start: range_start, stop: range_stop)
+          |> filter(fn: (r) => r._measurement == "stock_minute")
+          |> filter(fn: (r) => {
+              kst = date.add(d: 9h, to: r._time)
+              h = date.hour(t: kst)
+              m = date.minute(t: kst)
+              return (h >= 9 and h < 15) or (h == 15 and m <= 30)
+          })
+        // 타임스탬프를 해당일의 15:00 UTC로 설정하는 함수
+        setTimestampTo15UTC = (r) => {
+          // Task 실행 시간을 기준으로 날짜의 시작(00:00 UTC)을 구함
+          day_start_utc = date.truncate(t: now(), unit: 1d)
+ 
+          return {
+            r with
+            _measurement: "stock_daily",
+            _time: date.add(d: 15h, to: day_start_utc)
+          }
+        }
+  
+        open = base
+          |> filter(fn: (r) => r._field == "openPrice")
+          |> aggregateWindow(every: 1d, fn: first)
+          |> map(fn: (r) => ({ r with _field: "openPrice" }))
+          |> map(fn: setTimestampTo15UTC)
+  
+        high = base
+          |> filter(fn: (r) => r._field == "maxPrice")
+          |> aggregateWindow(every: 1d, fn: max)
+          |> map(fn: (r) => ({ r with _field: "maxPrice" }))
+          |> map(fn: setTimestampTo15UTC)
+  
+        low = base
+          |> filter(fn: (r) => r._field == "minPrice")
+          |> aggregateWindow(every: 1d, fn: min)
+          |> map(fn: (r) => ({ r with _field: "minPrice" }))
+          |> map(fn: setTimestampTo15UTC)
+  
+        close = base
+          |> filter(fn: (r) => r._field == "closePrice")
+          |> aggregateWindow(every: 1d, fn: last)
+          |> map(fn: (r) => ({ r with _field: "closePrice" }))
+          |> map(fn: setTimestampTo15UTC)
+  
+        volume = base
+          |> filter(fn: (r) => r._field == "accumTrans")
+          |> aggregateWindow(every: 1d, fn: last)
+          |> map(fn: (r) => ({ r with _field: "accumTrans" }))
+          |> map(fn: setTimestampTo15UTC)
+  
+        union(tables: [open, high, low, close, volume])
+          |> to(bucket: "%s", org: "%s")
+        """,
+        TASK_NAME, minuteBucket, dailyBucket, influxOrg);
+  }
+
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
@@ -1,0 +1,120 @@
+package io.gaboja9.mockstock.global.influx;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.TasksApi;
+import com.influxdb.client.domain.Task;
+import com.influxdb.client.domain.TaskStatusType;
+
+import jakarta.annotation.PostConstruct;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class FiveMinuteTaskInitializer {
+
+  @Value("${spring.influx.org}")
+  private String influxOrg;
+
+  @Value("${spring.influx.bucket.minute}")
+  private String minuteBucket;
+
+  private static final String TASK_NAME = "5분봉 실시간 생성 (장중 전용)";
+
+  private final InfluxDBClient minuteInfluxDBClient;
+
+  public FiveMinuteTaskInitializer(
+      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+    this.minuteInfluxDBClient = minuteInfluxDBClient;
+  }
+
+  @PostConstruct
+  public void initializeFiveMinuteTask() {
+    TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
+
+    try {
+      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
+
+      if (existingTask.isPresent()) {
+        Task task = existingTask.get();
+        log.info(
+            "5-minute task '{}' already exists (ID: {}, Status: {})",
+            TASK_NAME,
+            task.getId(),
+            task.getStatus());
+
+        if (task.getStatus() == TaskStatusType.INACTIVE) {
+          task.setStatus(TaskStatusType.ACTIVE);
+          tasksApi.updateTask(task);
+          log.info("Activated 5-minute task '{}'", TASK_NAME);
+        }
+      } else {
+        createNewTask(tasksApi);
+      }
+    } catch (Exception e) {
+      log.error("Failed to initialize 5-minute task '{}'", TASK_NAME, e);
+    }
+  }
+
+  private void createNewTask(TasksApi tasksApi) {
+    log.info("Creating new 5-minute task: {}", TASK_NAME);
+
+    Task newTask = new Task();
+    newTask.setName(TASK_NAME);
+    newTask.setOrg(influxOrg);
+    newTask.setStatus(TaskStatusType.ACTIVE);
+    newTask.setDescription("5분마다 1분봉 데이터를 집계하여 5분봉 생성 후 동일 버킷에 저장");
+    newTask.setFlux(generateFluxScript());
+
+    Task createdTask = tasksApi.createTask(newTask);
+    log.info(
+        "Successfully created 5-minute task '{}' with ID: {}",
+        TASK_NAME,
+        createdTask.getId());
+  }
+
+  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+    List<Task> tasks = tasksApi.findTasks();
+    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+  }
+
+  private String generateFluxScript() {
+    return String.format(
+        """
+        import "date"
+        option task = { name: "%s", every: 5m, offset: 1m }
+        // 1. 월봉/주봉 스크립트와 동일한 구조를 위해 시간 범위를 계산합니다.
+        range_stop = date.truncate(t: now(), unit: 5m)   // 예: 12:10:00
+        range_start = date.sub(d: 5m, from: range_stop)    // 예: 12:05:00
+        // 2. 원본 데이터를 조회합니다. (12:05:00 <= t < 12:10:00)
+        base = from(bucket: "%s")
+          |> range(start: range_start, stop: range_stop)
+          |> filter(fn: (r) => r._measurement == "stock_minute")
+          |> filter(fn: (r) => {
+              kst = date.add(d: 9h, to: r._time)
+              h = date.hour(t: kst)
+              m = date.minute(t: kst)
+              return (h >= 9 and h < 15) or (h == 15 and m <= 30)
+          })
+        // 3. 각 필드별로 5분봉을 집계합니다.
+        // timeSrc를 생략하면 윈도우의 종료 시점(range_stop)이 타임스탬프가 됩니다.
+        open = base |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first)
+        high = base |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max)
+        low = base |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min)
+        close = base |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last)
+        volume = base |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum)
+        // 4. 집계된 데이터들을 하나로 합치고 "stock_5minute"으로 이름을 바꿔 저장합니다.
+        union(tables: [open, high, low, close, volume])
+          |> map(fn: (r) => ({ r with _measurement: "stock_5minute" }))
+          |> to(bucket: "%s", org: "%s")
+        """,
+        TASK_NAME, minuteBucket, minuteBucket, influxOrg);
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
@@ -20,101 +20,101 @@ import java.util.Optional;
 @Slf4j
 public class FiveMinuteTaskInitializer {
 
-  @Value("${spring.influx.org}")
-  private String influxOrg;
+    @Value("${spring.influx.org}")
+    private String influxOrg;
 
-  @Value("${spring.influx.bucket.minute}")
-  private String minuteBucket;
+    @Value("${spring.influx.bucket.minute}")
+    private String minuteBucket;
 
-  private static final String TASK_NAME = "5분봉 실시간 생성 (장중 전용)";
+    private static final String TASK_NAME = "5분봉 실시간 생성 (장중 전용)";
 
-  private final InfluxDBClient minuteInfluxDBClient;
+    private final InfluxDBClient minuteInfluxDBClient;
 
-  public FiveMinuteTaskInitializer(
-      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
-    this.minuteInfluxDBClient = minuteInfluxDBClient;
-  }
-
-  @PostConstruct
-  public void initializeFiveMinuteTask() {
-    TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
-
-    try {
-      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
-
-      if (existingTask.isPresent()) {
-        Task task = existingTask.get();
-        log.info(
-            "5-minute task '{}' already exists (ID: {}, Status: {})",
-            TASK_NAME,
-            task.getId(),
-            task.getStatus());
-
-        if (task.getStatus() == TaskStatusType.INACTIVE) {
-          task.setStatus(TaskStatusType.ACTIVE);
-          tasksApi.updateTask(task);
-          log.info("Activated 5-minute task '{}'", TASK_NAME);
-        }
-      } else {
-        createNewTask(tasksApi);
-      }
-    } catch (Exception e) {
-      log.error("Failed to initialize 5-minute task '{}'", TASK_NAME, e);
+    public FiveMinuteTaskInitializer(
+            @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+        this.minuteInfluxDBClient = minuteInfluxDBClient;
     }
-  }
 
-  private void createNewTask(TasksApi tasksApi) {
-    log.info("Creating new 5-minute task: {}", TASK_NAME);
+    @PostConstruct
+    public void initializeFiveMinuteTask() {
+        TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
 
-    Task newTask = new Task();
-    newTask.setName(TASK_NAME);
-    newTask.setOrg(influxOrg);
-    newTask.setStatus(TaskStatusType.ACTIVE);
-    newTask.setDescription("5분마다 1분봉 데이터를 집계하여 5분봉 생성 후 동일 버킷에 저장");
-    newTask.setFlux(generateFluxScript());
+        try {
+            Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
 
-    Task createdTask = tasksApi.createTask(newTask);
-    log.info(
-        "Successfully created 5-minute task '{}' with ID: {}",
-        TASK_NAME,
-        createdTask.getId());
-  }
+            if (existingTask.isPresent()) {
+                Task task = existingTask.get();
+                log.info(
+                        "5-minute task '{}' already exists (ID: {}, Status: {})",
+                        TASK_NAME,
+                        task.getId(),
+                        task.getStatus());
 
-  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
-    List<Task> tasks = tasksApi.findTasks();
-    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
-  }
+                if (task.getStatus() == TaskStatusType.INACTIVE) {
+                    task.setStatus(TaskStatusType.ACTIVE);
+                    tasksApi.updateTask(task);
+                    log.info("Activated 5-minute task '{}'", TASK_NAME);
+                }
+            } else {
+                createNewTask(tasksApi);
+            }
+        } catch (Exception e) {
+            log.error("Failed to initialize 5-minute task '{}'", TASK_NAME, e);
+        }
+    }
 
-  private String generateFluxScript() {
-    return String.format(
-        """
-        import "date"
-        option task = { name: "%s", every: 5m, offset: 1m }
-        // 1. 월봉/주봉 스크립트와 동일한 구조를 위해 시간 범위를 계산합니다.
-        range_stop = date.truncate(t: now(), unit: 5m)   // 예: 12:10:00
-        range_start = date.sub(d: 5m, from: range_stop)    // 예: 12:05:00
-        // 2. 원본 데이터를 조회합니다. (12:05:00 <= t < 12:10:00)
-        base = from(bucket: "%s")
-          |> range(start: range_start, stop: range_stop)
-          |> filter(fn: (r) => r._measurement == "stock_minute")
-          |> filter(fn: (r) => {
-              kst = date.add(d: 9h, to: r._time)
-              h = date.hour(t: kst)
-              m = date.minute(t: kst)
-              return (h >= 9 and h < 15) or (h == 15 and m <= 30)
-          })
-        // 3. 각 필드별로 5분봉을 집계합니다.
-        // timeSrc를 생략하면 윈도우의 종료 시점(range_stop)이 타임스탬프가 됩니다.
-        open = base |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first)
-        high = base |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max)
-        low = base |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min)
-        close = base |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last)
-        volume = base |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum)
-        // 4. 집계된 데이터들을 하나로 합치고 "stock_5minute"으로 이름을 바꿔 저장합니다.
-        union(tables: [open, high, low, close, volume])
-          |> map(fn: (r) => ({ r with _measurement: "stock_5minute" }))
-          |> to(bucket: "%s", org: "%s")
-        """,
-        TASK_NAME, minuteBucket, minuteBucket, influxOrg);
-  }
+    private void createNewTask(TasksApi tasksApi) {
+        log.info("Creating new 5-minute task: {}", TASK_NAME);
+
+        Task newTask = new Task();
+        newTask.setName(TASK_NAME);
+        newTask.setOrg(influxOrg);
+        newTask.setStatus(TaskStatusType.ACTIVE);
+        newTask.setDescription("5분마다 1분봉 데이터를 집계하여 5분봉 생성 후 동일 버킷에 저장");
+        newTask.setFlux(generateFluxScript());
+
+        Task createdTask = tasksApi.createTask(newTask);
+        log.info(
+                "Successfully created 5-minute task '{}' with ID: {}",
+                TASK_NAME,
+                createdTask.getId());
+    }
+
+    private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+        List<Task> tasks = tasksApi.findTasks();
+        return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+    }
+
+    private String generateFluxScript() {
+        return String.format(
+                """
+                import "date"
+                option task = { name: "%s", every: 5m, offset: 1m }
+                // 1. 월봉/주봉 스크립트와 동일한 구조를 위해 시간 범위를 계산합니다.
+                range_stop = date.truncate(t: now(), unit: 5m)   // 예: 12:10:00
+                range_start = date.sub(d: 5m, from: range_stop)    // 예: 12:05:00
+                // 2. 원본 데이터를 조회합니다. (12:05:00 <= t < 12:10:00)
+                base = from(bucket: "%s")
+                  |> range(start: range_start, stop: range_stop)
+                  |> filter(fn: (r) => r._measurement == "stock_minute")
+                  |> filter(fn: (r) => {
+                      kst = date.add(d: 9h, to: r._time)
+                      h = date.hour(t: kst)
+                      m = date.minute(t: kst)
+                      return (h >= 9 and h < 15) or (h == 15 and m <= 30)
+                  })
+                // 3. 각 필드별로 5분봉을 집계합니다.
+                // timeSrc를 생략하면 윈도우의 종료 시점(range_stop)이 타임스탬프가 됩니다.
+                open = base |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first)
+                high = base |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max)
+                low = base |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min)
+                close = base |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last)
+                volume = base |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum)
+                // 4. 집계된 데이터들을 하나로 합치고 "stock_5minute"으로 이름을 바꿔 저장합니다.
+                union(tables: [open, high, low, close, volume])
+                  |> map(fn: (r) => ({ r with _measurement: "stock_5minute" }))
+                  |> to(bucket: "%s", org: "%s")
+                """,
+                TASK_NAME, minuteBucket, minuteBucket, influxOrg);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/FiveMinuteTaskInitializer.java
@@ -20,103 +20,103 @@ import java.util.Optional;
 @Slf4j
 public class FiveMinuteTaskInitializer {
 
-  @Value("${spring.influx.org}")
-  private String influxOrg;
+    @Value("${spring.influx.org}")
+    private String influxOrg;
 
-  @Value("${spring.influx.bucket.minute}")
-  private String minuteBucket;
+    @Value("${spring.influx.bucket.minute}")
+    private String minuteBucket;
 
-  private static final String TASK_NAME = "5분봉 실시간 생성 (장중 전용)";
+    private static final String TASK_NAME = "5분봉 실시간 생성 (장중 전용)";
 
-  private final InfluxDBClient minuteInfluxDBClient;
+    private final InfluxDBClient minuteInfluxDBClient;
 
-  public FiveMinuteTaskInitializer(
-      @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
-    this.minuteInfluxDBClient = minuteInfluxDBClient;
-  }
-
-  @PostConstruct
-  public void initializeFiveMinuteTask() {
-    TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
-
-    try {
-      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
-
-      if (existingTask.isPresent()) {
-        Task task = existingTask.get();
-        log.info(
-            "5-minute task '{}' already exists (ID: {}, Status: {})",
-            TASK_NAME,
-            task.getId(),
-            task.getStatus());
-
-        if (task.getStatus() == TaskStatusType.INACTIVE) {
-          task.setStatus(TaskStatusType.ACTIVE);
-          tasksApi.updateTask(task);
-          log.info("Activated 5-minute task '{}'", TASK_NAME);
-        }
-      } else {
-        createNewTask(tasksApi);
-      }
-    } catch (Exception e) {
-      log.error("Failed to initialize 5-minute task '{}'", TASK_NAME, e);
+    public FiveMinuteTaskInitializer(
+            @Qualifier("minuteInfluxDBClient") InfluxDBClient minuteInfluxDBClient) {
+        this.minuteInfluxDBClient = minuteInfluxDBClient;
     }
-  }
 
-  private void createNewTask(TasksApi tasksApi) {
-    log.info("Creating new 5-minute task: {}", TASK_NAME);
+    @PostConstruct
+    public void initializeFiveMinuteTask() {
+        TasksApi tasksApi = minuteInfluxDBClient.getTasksApi();
 
-    Task newTask = new Task();
-    newTask.setName(TASK_NAME);
-    newTask.setOrg(influxOrg);
-    newTask.setStatus(TaskStatusType.ACTIVE);
-    newTask.setDescription("5분마다 1분봉 데이터를 집계하여 5분봉 생성 후 동일 버킷에 저장");
-    newTask.setFlux(generateFluxScript());
+        try {
+            Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
 
-    Task createdTask = tasksApi.createTask(newTask);
-    log.info(
-        "Successfully created 5-minute task '{}' with ID: {}",
-        TASK_NAME,
-        createdTask.getId());
-  }
+            if (existingTask.isPresent()) {
+                Task task = existingTask.get();
+                log.info(
+                        "5-minute task '{}' already exists (ID: {}, Status: {})",
+                        TASK_NAME,
+                        task.getId(),
+                        task.getStatus());
 
-  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
-    List<Task> tasks = tasksApi.findTasks();
-    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
-  }
+                if (task.getStatus() == TaskStatusType.INACTIVE) {
+                    task.setStatus(TaskStatusType.ACTIVE);
+                    tasksApi.updateTask(task);
+                    log.info("Activated 5-minute task '{}'", TASK_NAME);
+                }
+            } else {
+                createNewTask(tasksApi);
+            }
+        } catch (Exception e) {
+            log.error("Failed to initialize 5-minute task '{}'", TASK_NAME, e);
+        }
+    }
 
-  private String generateFluxScript() {
-    return String.format(
-        """
-        import "date"
-        option task = { name: "%s", every: 5m, offset: 1m }
-        // 1. 월봉/주봉 스크립트와 동일한 구조를 위해 시간 범위를 계산합니다.
-        range_stop = date.truncate(t: now(), unit: 5m)   // 예: 12:10:00
-        range_start = date.sub(d: 5m, from: range_stop)    // 예: 12:05:00
+    private void createNewTask(TasksApi tasksApi) {
+        log.info("Creating new 5-minute task: {}", TASK_NAME);
 
-        base = from(bucket: "%s")
-          |> range(start: range_start, stop: range_stop)
-          |> filter(fn: (r) => r._measurement == "stock_minute")
-          |> filter(fn: (r) => {
-              kst = date.add(d: 9h, to: r._time)
-              h = date.hour(t: kst)
-              m = date.minute(t: kst)
-              return (h >= 9 and h < 15) or (h == 15 and m <= 30)
-          })
-        
-        // 3. 각 필드별로 5분봉을 집계합니다.
-        // timeSrc를 생략하면 윈도우의 종료 시점(range_stop)이 타임스탬프가 됩니다.
-        open = base |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first)
-        high = base |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max)
-        low = base |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min)
-        close = base |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last)
-        volume = base |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum)
-        
-        // 4. 집계된 데이터들을 하나로 합치고 "stock_5minute"으로 이름을 바꿔 저장합니다.
-        union(tables: [open, high, low, close, volume])
-          |> map(fn: (r) => ({ r with _measurement: "stock_5minute" }))
-          |> to(bucket: "%s", org: "%s")
-        """,
-        TASK_NAME, minuteBucket, minuteBucket, influxOrg);
-  }
+        Task newTask = new Task();
+        newTask.setName(TASK_NAME);
+        newTask.setOrg(influxOrg);
+        newTask.setStatus(TaskStatusType.ACTIVE);
+        newTask.setDescription("5분마다 1분봉 데이터를 집계하여 5분봉 생성 후 동일 버킷에 저장");
+        newTask.setFlux(generateFluxScript());
+
+        Task createdTask = tasksApi.createTask(newTask);
+        log.info(
+                "Successfully created 5-minute task '{}' with ID: {}",
+                TASK_NAME,
+                createdTask.getId());
+    }
+
+    private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+        List<Task> tasks = tasksApi.findTasks();
+        return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+    }
+
+    private String generateFluxScript() {
+        return String.format(
+                """
+                import "date"
+                option task = { name: "%s", every: 5m, offset: 1m }
+                // 1. 월봉/주봉 스크립트와 동일한 구조를 위해 시간 범위를 계산합니다.
+                range_stop = date.truncate(t: now(), unit: 5m)   // 예: 12:10:00
+                range_start = date.sub(d: 5m, from: range_stop)    // 예: 12:05:00
+
+                base = from(bucket: "%s")
+                  |> range(start: range_start, stop: range_stop)
+                  |> filter(fn: (r) => r._measurement == "stock_minute")
+                  |> filter(fn: (r) => {
+                      kst = date.add(d: 9h, to: r._time)
+                      h = date.hour(t: kst)
+                      m = date.minute(t: kst)
+                      return (h >= 9 and h < 15) or (h == 15 and m <= 30)
+                  })
+
+                // 3. 각 필드별로 5분봉을 집계합니다.
+                // timeSrc를 생략하면 윈도우의 종료 시점(range_stop)이 타임스탬프가 됩니다.
+                open = base |> filter(fn: (r) => r._field == "openPrice") |> aggregateWindow(every: 5m, fn: first)
+                high = base |> filter(fn: (r) => r._field == "maxPrice") |> aggregateWindow(every: 5m, fn: max)
+                low = base |> filter(fn: (r) => r._field == "minPrice") |> aggregateWindow(every: 5m, fn: min)
+                close = base |> filter(fn: (r) => r._field == "closePrice") |> aggregateWindow(every: 5m, fn: last)
+                volume = base |> filter(fn: (r) => r._field == "accumTrans") |> aggregateWindow(every: 5m, fn: sum)
+
+                // 4. 집계된 데이터들을 하나로 합치고 "stock_5minute"으로 이름을 바꿔 저장합니다.
+                union(tables: [open, high, low, close, volume])
+                  |> map(fn: (r) => ({ r with _measurement: "stock_5minute" }))
+                  |> to(bucket: "%s", org: "%s")
+                """,
+                TASK_NAME, minuteBucket, minuteBucket, influxOrg);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/MonthlyTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/MonthlyTaskInitializer.java
@@ -1,0 +1,170 @@
+package io.gaboja9.mockstock.global.influx;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.TasksApi;
+import com.influxdb.client.domain.Task;
+import com.influxdb.client.domain.TaskStatusType;
+
+import jakarta.annotation.PostConstruct;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class MonthlyTaskInitializer {
+
+  private final InfluxDBClient influxDBClient;
+
+  @Value("${spring.influx.org}")
+  private String influxOrg;
+
+  @Value("${spring.influx.bucket.daily}")
+  private String bucket;
+
+  private static final String TASK_NAME = "일봉 to 월봉 변환 작업";
+
+  // 수동 생성자 주입
+  public MonthlyTaskInitializer(@Qualifier("dailyInfluxDBClient") InfluxDBClient influxDBClient) {
+    this.influxDBClient = influxDBClient;
+  }
+
+  @PostConstruct
+  public void initializeMonthlyTask() {
+    TasksApi tasksApi = influxDBClient.getTasksApi();
+
+    try {
+      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
+
+      if (existingTask.isPresent()) {
+        Task task = existingTask.get();
+        log.info(
+            "Monthly task '{}' already exists (ID: {}, Status: {})",
+            TASK_NAME,
+            task.getId(),
+            task.getStatus());
+
+        if (task.getStatus() == TaskStatusType.INACTIVE) {
+          task.setStatus(TaskStatusType.ACTIVE);
+          tasksApi.updateTask(task);
+          log.info("Activated monthly task '{}'", TASK_NAME);
+        }
+      } else {
+        createNewTask(tasksApi);
+      }
+
+    } catch (Exception e) {
+      log.error("Failed to initialize monthly task '{}'", TASK_NAME, e);
+    }
+  }
+
+  private void createNewTask(TasksApi tasksApi) {
+    log.info("Creating new monthly task: {}", TASK_NAME);
+
+    Task newTask = new Task();
+    newTask.setName(TASK_NAME);
+    newTask.setOrg(influxOrg);
+    newTask.setStatus(TaskStatusType.ACTIVE);
+    newTask.setDescription("매월 1일 오전 6시에 일봉 데이터를 월봉으로 변환");
+    newTask.setFlux(generateFluxScript());
+
+    Task createdTask = tasksApi.createTask(newTask);
+    log.info(
+        "Successfully created monthly task '{}' with ID: {}",
+        TASK_NAME,
+        createdTask.getId());
+  }
+
+  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+    List<Task> tasks = tasksApi.findTasks();
+    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+  }
+
+  private String generateFluxScript() {
+    return String.format(
+        """
+        import "date"
+
+        option task = {
+          name: "%s",
+          every: 1mo,
+          offset: 6h
+        }
+
+        // 이전 달 데이터만 조회해서 이전 달 월봉 생성
+        range_stop = date.truncate(t: now(), unit: 1mo)           // 이번 달 1일 00:00:00
+        range_start = date.sub(d: 1mo, from: range_stop)          // 지난 달 1일 00:00:00
+        
+        base = from(bucket: "%s")
+          |> range(start: range_start, stop: range_stop)
+          |> filter(fn: (r) => r._measurement == "stock_daily")
+          |> filter(fn: (r) => {
+              weekday = date.weekDay(t: r._time)
+              return weekday >= 1 and weekday <= 5
+          })
+
+        // 각 필드별로 월봉 데이터 집계하고, 타임스탬프를 월 마지막 날 한국시간 00:00 (UTC 15:00 전날)로 조정
+        open = base
+          |> filter(fn: (r) => r._field == "openPrice")
+          |> aggregateWindow(every: 1mo, fn: first)
+          |> map(fn: (r) => ({ 
+              r with 
+              _field: "openPrice", 
+              _measurement: "stock_monthly",
+              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+          }))
+
+        high = base
+          |> filter(fn: (r) => r._field == "maxPrice")
+          |> aggregateWindow(every: 1mo, fn: max)
+          |> map(fn: (r) => ({ 
+              r with 
+              _field: "maxPrice", 
+              _measurement: "stock_monthly",
+              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+          }))
+
+        low = base
+          |> filter(fn: (r) => r._field == "minPrice")
+          |> aggregateWindow(every: 1mo, fn: min)
+          |> map(fn: (r) => ({ 
+              r with 
+              _field: "minPrice", 
+              _measurement: "stock_monthly",
+              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+          }))
+
+        close = base
+          |> filter(fn: (r) => r._field == "closePrice")
+          |> aggregateWindow(every: 1mo, fn: last)
+          |> map(fn: (r) => ({ 
+              r with 
+              _field: "closePrice", 
+              _measurement: "stock_monthly",
+              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+          }))
+
+        volume = base
+          |> filter(fn: (r) => r._field == "accumTrans")
+          |> aggregateWindow(every: 1mo, fn: sum)
+          |> map(fn: (r) => ({ 
+              r with 
+              _field: "accumTrans", 
+              _measurement: "stock_monthly",
+              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+          }))
+
+        // 집계된 데이터를 하나로 합쳐서 최종 저장
+        union(tables: [open, high, low, close, volume])
+          |> to(bucket: "%s", org: "%s")
+
+        """,
+        TASK_NAME, bucket, bucket, influxOrg);
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/MonthlyTaskInitializer.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/influx/MonthlyTaskInitializer.java
@@ -20,151 +20,151 @@ import java.util.Optional;
 @Slf4j
 public class MonthlyTaskInitializer {
 
-  private final InfluxDBClient influxDBClient;
+    private final InfluxDBClient influxDBClient;
 
-  @Value("${spring.influx.org}")
-  private String influxOrg;
+    @Value("${spring.influx.org}")
+    private String influxOrg;
 
-  @Value("${spring.influx.bucket.daily}")
-  private String bucket;
+    @Value("${spring.influx.bucket.daily}")
+    private String bucket;
 
-  private static final String TASK_NAME = "일봉 to 월봉 변환 작업";
+    private static final String TASK_NAME = "일봉 to 월봉 변환 작업";
 
-  // 수동 생성자 주입
-  public MonthlyTaskInitializer(@Qualifier("dailyInfluxDBClient") InfluxDBClient influxDBClient) {
-    this.influxDBClient = influxDBClient;
-  }
-
-  @PostConstruct
-  public void initializeMonthlyTask() {
-    TasksApi tasksApi = influxDBClient.getTasksApi();
-
-    try {
-      Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
-
-      if (existingTask.isPresent()) {
-        Task task = existingTask.get();
-        log.info(
-            "Monthly task '{}' already exists (ID: {}, Status: {})",
-            TASK_NAME,
-            task.getId(),
-            task.getStatus());
-
-        if (task.getStatus() == TaskStatusType.INACTIVE) {
-          task.setStatus(TaskStatusType.ACTIVE);
-          tasksApi.updateTask(task);
-          log.info("Activated monthly task '{}'", TASK_NAME);
-        }
-      } else {
-        createNewTask(tasksApi);
-      }
-
-    } catch (Exception e) {
-      log.error("Failed to initialize monthly task '{}'", TASK_NAME, e);
+    // 수동 생성자 주입
+    public MonthlyTaskInitializer(@Qualifier("dailyInfluxDBClient") InfluxDBClient influxDBClient) {
+        this.influxDBClient = influxDBClient;
     }
-  }
 
-  private void createNewTask(TasksApi tasksApi) {
-    log.info("Creating new monthly task: {}", TASK_NAME);
+    @PostConstruct
+    public void initializeMonthlyTask() {
+        TasksApi tasksApi = influxDBClient.getTasksApi();
 
-    Task newTask = new Task();
-    newTask.setName(TASK_NAME);
-    newTask.setOrg(influxOrg);
-    newTask.setStatus(TaskStatusType.ACTIVE);
-    newTask.setDescription("매월 1일 오전 6시에 일봉 데이터를 월봉으로 변환");
-    newTask.setFlux(generateFluxScript());
+        try {
+            Optional<Task> existingTask = findTaskByName(tasksApi, TASK_NAME);
 
-    Task createdTask = tasksApi.createTask(newTask);
-    log.info(
-        "Successfully created monthly task '{}' with ID: {}",
-        TASK_NAME,
-        createdTask.getId());
-  }
+            if (existingTask.isPresent()) {
+                Task task = existingTask.get();
+                log.info(
+                        "Monthly task '{}' already exists (ID: {}, Status: {})",
+                        TASK_NAME,
+                        task.getId(),
+                        task.getStatus());
 
-  private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
-    List<Task> tasks = tasksApi.findTasks();
-    return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
-  }
+                if (task.getStatus() == TaskStatusType.INACTIVE) {
+                    task.setStatus(TaskStatusType.ACTIVE);
+                    tasksApi.updateTask(task);
+                    log.info("Activated monthly task '{}'", TASK_NAME);
+                }
+            } else {
+                createNewTask(tasksApi);
+            }
 
-  private String generateFluxScript() {
-    return String.format(
-        """
-        import "date"
-
-        option task = {
-          name: "%s",
-          every: 1mo,
-          offset: 6h
+        } catch (Exception e) {
+            log.error("Failed to initialize monthly task '{}'", TASK_NAME, e);
         }
+    }
 
-        // 이전 달 데이터만 조회해서 이전 달 월봉 생성
-        range_stop = date.truncate(t: now(), unit: 1mo)           // 이번 달 1일 00:00:00
-        range_start = date.sub(d: 1mo, from: range_stop)          // 지난 달 1일 00:00:00
-        
-        base = from(bucket: "%s")
-          |> range(start: range_start, stop: range_stop)
-          |> filter(fn: (r) => r._measurement == "stock_daily")
-          |> filter(fn: (r) => {
-              weekday = date.weekDay(t: r._time)
-              return weekday >= 1 and weekday <= 5
-          })
+    private void createNewTask(TasksApi tasksApi) {
+        log.info("Creating new monthly task: {}", TASK_NAME);
 
-        // 각 필드별로 월봉 데이터 집계하고, 타임스탬프를 월 마지막 날 한국시간 00:00 (UTC 15:00 전날)로 조정
-        open = base
-          |> filter(fn: (r) => r._field == "openPrice")
-          |> aggregateWindow(every: 1mo, fn: first)
-          |> map(fn: (r) => ({ 
-              r with 
-              _field: "openPrice", 
-              _measurement: "stock_monthly",
-              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
-          }))
+        Task newTask = new Task();
+        newTask.setName(TASK_NAME);
+        newTask.setOrg(influxOrg);
+        newTask.setStatus(TaskStatusType.ACTIVE);
+        newTask.setDescription("매월 1일 오전 6시에 일봉 데이터를 월봉으로 변환");
+        newTask.setFlux(generateFluxScript());
 
-        high = base
-          |> filter(fn: (r) => r._field == "maxPrice")
-          |> aggregateWindow(every: 1mo, fn: max)
-          |> map(fn: (r) => ({ 
-              r with 
-              _field: "maxPrice", 
-              _measurement: "stock_monthly",
-              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
-          }))
+        Task createdTask = tasksApi.createTask(newTask);
+        log.info(
+                "Successfully created monthly task '{}' with ID: {}",
+                TASK_NAME,
+                createdTask.getId());
+    }
 
-        low = base
-          |> filter(fn: (r) => r._field == "minPrice")
-          |> aggregateWindow(every: 1mo, fn: min)
-          |> map(fn: (r) => ({ 
-              r with 
-              _field: "minPrice", 
-              _measurement: "stock_monthly",
-              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
-          }))
+    private Optional<Task> findTaskByName(TasksApi tasksApi, String name) {
+        List<Task> tasks = tasksApi.findTasks();
+        return tasks.stream().filter(task -> name.equals(task.getName())).findFirst();
+    }
 
-        close = base
-          |> filter(fn: (r) => r._field == "closePrice")
-          |> aggregateWindow(every: 1mo, fn: last)
-          |> map(fn: (r) => ({ 
-              r with 
-              _field: "closePrice", 
-              _measurement: "stock_monthly",
-              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
-          }))
+    private String generateFluxScript() {
+        return String.format(
+                """
+                import "date"
 
-        volume = base
-          |> filter(fn: (r) => r._field == "accumTrans")
-          |> aggregateWindow(every: 1mo, fn: sum)
-          |> map(fn: (r) => ({ 
-              r with 
-              _field: "accumTrans", 
-              _measurement: "stock_monthly",
-              _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
-          }))
+                option task = {
+                  name: "%s",
+                  every: 1mo,
+                  offset: 6h
+                }
 
-        // 집계된 데이터를 하나로 합쳐서 최종 저장
-        union(tables: [open, high, low, close, volume])
-          |> to(bucket: "%s", org: "%s")
+                // 이전 달 데이터만 조회해서 이전 달 월봉 생성
+                range_stop = date.truncate(t: now(), unit: 1mo)           // 이번 달 1일 00:00:00
+                range_start = date.sub(d: 1mo, from: range_stop)          // 지난 달 1일 00:00:00
 
-        """,
-        TASK_NAME, bucket, bucket, influxOrg);
-  }
+                base = from(bucket: "%s")
+                  |> range(start: range_start, stop: range_stop)
+                  |> filter(fn: (r) => r._measurement == "stock_daily")
+                  |> filter(fn: (r) => {
+                      weekday = date.weekDay(t: r._time)
+                      return weekday >= 1 and weekday <= 5
+                  })
+
+                // 각 필드별로 월봉 데이터 집계하고, 타임스탬프를 월 마지막 날 한국시간 00:00 (UTC 15:00 전날)로 조정
+                open = base
+                  |> filter(fn: (r) => r._field == "openPrice")
+                  |> aggregateWindow(every: 1mo, fn: first)
+                  |> map(fn: (r) => ({
+                      r with
+                      _field: "openPrice",
+                      _measurement: "stock_monthly",
+                      _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+                  }))
+
+                high = base
+                  |> filter(fn: (r) => r._field == "maxPrice")
+                  |> aggregateWindow(every: 1mo, fn: max)
+                  |> map(fn: (r) => ({
+                      r with
+                      _field: "maxPrice",
+                      _measurement: "stock_monthly",
+                      _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+                  }))
+
+                low = base
+                  |> filter(fn: (r) => r._field == "minPrice")
+                  |> aggregateWindow(every: 1mo, fn: min)
+                  |> map(fn: (r) => ({
+                      r with
+                      _field: "minPrice",
+                      _measurement: "stock_monthly",
+                      _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+                  }))
+
+                close = base
+                  |> filter(fn: (r) => r._field == "closePrice")
+                  |> aggregateWindow(every: 1mo, fn: last)
+                  |> map(fn: (r) => ({
+                      r with
+                      _field: "closePrice",
+                      _measurement: "stock_monthly",
+                      _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+                  }))
+
+                volume = base
+                  |> filter(fn: (r) => r._field == "accumTrans")
+                  |> aggregateWindow(every: 1mo, fn: sum)
+                  |> map(fn: (r) => ({
+                      r with
+                      _field: "accumTrans",
+                      _measurement: "stock_monthly",
+                      _time: date.sub(d: 33h, from: date.add(d: 1mo, to: date.truncate(t: r._time, unit: 1mo)))
+                  }))
+
+                // 집계된 데이터를 하나로 합쳐서 최종 저장
+                union(tables: [open, high, low, close, volume])
+                  |> to(bucket: "%s", org: "%s")
+
+                """,
+                TASK_NAME, bucket, bucket, influxOrg);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/MockStockController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/MockStockController.java
@@ -1,66 +1,21 @@
 package io.gaboja9.mockstock.global.websocket.controller;
 
 import io.gaboja9.mockstock.global.websocket.dto.StockPriceDto;
-
+import io.gaboja9.mockstock.global.websocket.service.MockStockService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
-
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class MockStockController {
 
-    private final SimpMessagingTemplate messagingTemplate;
-    private static final DateTimeFormatter HHMMSS = DateTimeFormatter.ofPattern("HHmmss");
+  private final MockStockService mockStockService;
 
-    @PostMapping("/mockPrice/{stockCode}")
-    public List<StockPriceDto> sendMockStockPrice(@PathVariable String stockCode) {
-
-        List<StockPriceDto> sent = new ArrayList<>();
-
-        for (int i = 0; i < 10; i++) { // 10회 반복
-
-            for (int j = 0; j < 2; j++) { // 1초 동안 2개씩 보냄
-
-                int currentPrice = 71400 + ThreadLocalRandom.current().nextInt(-100, 101);
-                int highPrice = currentPrice + ThreadLocalRandom.current().nextInt(1, 6);
-                int lowPrice = currentPrice - ThreadLocalRandom.current().nextInt(1, 6);
-
-                StockPriceDto priceData =
-                        StockPriceDto.builder()
-                                .stockCode(stockCode)
-                                .currentPrice(currentPrice)
-                                .dayOverDayPercent(-1.65 + (j * 0.01))
-                                .tradeTime(LocalTime.now().format(HHMMSS))
-                                .tradeVolume(100L + j)
-                                .highPrice(highPrice)
-                                .lowPrice(lowPrice)
-                                .cumulativeVolume(25000L + i * 2 + j)
-                                .build();
-
-                messagingTemplate.convertAndSend("/topic/stock/" + stockCode, priceData);
-                log.info("[MOCK→STOMP] {}: {}", stockCode, priceData);
-                sent.add(priceData);
-            }
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        return sent;
-    }
+  @PostMapping("/mockPrice/{stockCode}")
+  public List<StockPriceDto> sendMockStockPrice(@PathVariable String stockCode) {
+    return mockStockService.sendMockPrices(stockCode);
+  }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/MockStockController.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/controller/MockStockController.java
@@ -2,20 +2,23 @@ package io.gaboja9.mockstock.global.websocket.controller;
 
 import io.gaboja9.mockstock.global.websocket.dto.StockPriceDto;
 import io.gaboja9.mockstock.global.websocket.service.MockStockService;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class MockStockController {
 
-  private final MockStockService mockStockService;
+    private final MockStockService mockStockService;
 
-  @PostMapping("/mockPrice/{stockCode}")
-  public List<StockPriceDto> sendMockStockPrice(@PathVariable String stockCode) {
-    return mockStockService.sendMockPrices(stockCode);
-  }
+    @PostMapping("/mockPrice/{stockCode}")
+    public List<StockPriceDto> sendMockStockPrice(@PathVariable String stockCode) {
+        return mockStockService.sendMockPrices(stockCode);
+    }
 }

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/MockStockService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/MockStockService.java
@@ -1,0 +1,61 @@
+package io.gaboja9.mockstock.global.websocket.service;
+
+import io.gaboja9.mockstock.global.websocket.dto.StockPriceDto;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MockStockService {
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private static final DateTimeFormatter HHMMSS = DateTimeFormatter.ofPattern("HHmmss");
+
+  /**
+   * 주어진 종목코드에 대해 10초간(매초 2회) 랜덤 주가를 생성하여 STOMP 토픽으로 전송하고, 보낸 데이터를 리스트로 반환합니다.
+   */
+  public List<StockPriceDto> sendMockPrices(String stockCode) {
+    List<StockPriceDto> sent = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 2; j++) {
+        int currentPrice = 71400 + ThreadLocalRandom.current().nextInt(-100, 101);
+        int highPrice = currentPrice + ThreadLocalRandom.current().nextInt(1, 6);
+        int lowPrice = currentPrice - ThreadLocalRandom.current().nextInt(1, 6);
+
+        StockPriceDto dto = StockPriceDto.builder()
+            .stockCode(stockCode)
+            .currentPrice(currentPrice)
+            .dayOverDayPercent(-1.65 + (j * 0.01))
+            .tradeTime(LocalTime.now().format(HHMMSS))
+            .tradeVolume(100L + j)
+            .highPrice(highPrice)
+            .lowPrice(lowPrice)
+            .cumulativeVolume(25_000L + i * 2 + j)
+            .build();
+
+        // STOMP 메시지 전송
+        messagingTemplate.convertAndSend("/topic/stock/" + stockCode, dto);
+        log.info("[MOCK→STOMP] {}: {}", stockCode, dto);
+        sent.add(dto);
+      }
+
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+
+    return sent;
+  }
+}

--- a/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/MockStockService.java
+++ b/MockStock/src/main/java/io/gaboja9/mockstock/global/websocket/service/MockStockService.java
@@ -1,61 +1,63 @@
 package io.gaboja9.mockstock.global.websocket.service;
 
 import io.gaboja9.mockstock.global.websocket.dto.StockPriceDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MockStockService {
 
-  private final SimpMessagingTemplate messagingTemplate;
-  private static final DateTimeFormatter HHMMSS = DateTimeFormatter.ofPattern("HHmmss");
+    private final SimpMessagingTemplate messagingTemplate;
+    private static final DateTimeFormatter HHMMSS = DateTimeFormatter.ofPattern("HHmmss");
 
-  /**
-   * 주어진 종목코드에 대해 10초간(매초 2회) 랜덤 주가를 생성하여 STOMP 토픽으로 전송하고, 보낸 데이터를 리스트로 반환합니다.
-   */
-  public List<StockPriceDto> sendMockPrices(String stockCode) {
-    List<StockPriceDto> sent = new ArrayList<>();
+    /** 주어진 종목코드에 대해 10초간(매초 2회) 랜덤 주가를 생성하여 STOMP 토픽으로 전송하고, 보낸 데이터를 리스트로 반환합니다. */
+    public List<StockPriceDto> sendMockPrices(String stockCode) {
+        List<StockPriceDto> sent = new ArrayList<>();
 
-    for (int i = 0; i < 10; i++) {
-      for (int j = 0; j < 2; j++) {
-        int currentPrice = 71400 + ThreadLocalRandom.current().nextInt(-100, 101);
-        int highPrice = currentPrice + ThreadLocalRandom.current().nextInt(1, 6);
-        int lowPrice = currentPrice - ThreadLocalRandom.current().nextInt(1, 6);
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 2; j++) {
+                int currentPrice = 71400 + ThreadLocalRandom.current().nextInt(-100, 101);
+                int highPrice = currentPrice + ThreadLocalRandom.current().nextInt(1, 6);
+                int lowPrice = currentPrice - ThreadLocalRandom.current().nextInt(1, 6);
 
-        StockPriceDto dto = StockPriceDto.builder()
-            .stockCode(stockCode)
-            .currentPrice(currentPrice)
-            .dayOverDayPercent(-1.65 + (j * 0.01))
-            .tradeTime(LocalTime.now().format(HHMMSS))
-            .tradeVolume(100L + j)
-            .highPrice(highPrice)
-            .lowPrice(lowPrice)
-            .cumulativeVolume(25_000L + i * 2 + j)
-            .build();
+                StockPriceDto dto =
+                        StockPriceDto.builder()
+                                .stockCode(stockCode)
+                                .currentPrice(currentPrice)
+                                .dayOverDayPercent(-1.65 + (j * 0.01))
+                                .tradeTime(LocalTime.now().format(HHMMSS))
+                                .tradeVolume(100L + j)
+                                .highPrice(highPrice)
+                                .lowPrice(lowPrice)
+                                .cumulativeVolume(25_000L + i * 2 + j)
+                                .build();
 
-        // STOMP 메시지 전송
-        messagingTemplate.convertAndSend("/topic/stock/" + stockCode, dto);
-        log.info("[MOCK→STOMP] {}: {}", stockCode, dto);
-        sent.add(dto);
-      }
+                // STOMP 메시지 전송
+                messagingTemplate.convertAndSend("/topic/stock/" + stockCode, dto);
+                log.info("[MOCK→STOMP] {}: {}", stockCode, dto);
+                sent.add(dto);
+            }
 
-      try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        break;
-      }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        return sent;
     }
-
-    return sent;
-  }
 }


### PR DESCRIPTION
## 관련 이슈
#167 

<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

## 개요

컨트롤러-서비스 역할 분리: 기존 컨트롤러의 비즈니스 로직을 서비스 레이어로 이전하여 계층 간 역할 분담을 명확히 했습니다.

데이터 처리 방식 개선: 5분봉 데이터 조회 및 저장 로직을 개선하여 효율성을 높였습니다.

InfluxDB Task 추가: 1분봉 데이터를 집계하여 5분봉, 일봉, 월봉 데이터를 생성하는 InfluxDB Task를 각각 추가했습니다.

5분봉 Task: 5분 간격으로 1분봉 데이터를 집계합니다.

일봉 Task: 매일 장 마감 후 당일 1분봉 데이터를 집계합니다.

월봉 Task: 매월 마지막 날, 해당 월의 일봉 데이터를 집계합니다.
